### PR TITLE
Issue#4: Reformat all cpp/hpp files according to clang-format

### DIFF
--- a/src/in_environment.cpp
+++ b/src/in_environment.cpp
@@ -19,133 +19,120 @@ environment is a cell array of the environment vertices
 epsilon is a double (the robustness constant).
 */
 
-
-//Gives Matlab interfacing.  Linkage block specifies linkage
-//convention used to link header file; makes the C header suitable for
-//C++ use.  "mex.h" also includes "matrix.h" to provide MX functions
-//to support Matlab data types, along with the standard header files
+// Gives Matlab interfacing.  Linkage block specifies linkage
+// convention used to link header file; makes the C header suitable for
+// C++ use.  "mex.h" also includes "matrix.h" to provide MX functions
+// to support Matlab data types, along with the standard header files
 //<stdio.h>, <stdlib.h>, and <stddef.h>.
 extern "C" {
-#include <math.h>
 #include "mex.h"
+#include <math.h>
 }
 
-
-#include "visilibity.hpp"  //VisiLibity header file
+#include "visilibity.hpp" //VisiLibity header file
 //#include <cmath>         //Puts math functions in std namespace
-#include <cstdlib>       //rand, srand, exit
-#include <ctime>         //Unix time
-#include <fstream>       //File I/O
-#include <iostream>      //std I/O
-#include <cstring>       //C-string manipulation
-#include <string>        //string class
-#include <sstream>       //string streams
-#include <vector>        //std vectors
+#include <cstdlib> //rand, srand, exit
+#include <cstring> //C-string manipulation
+#include <ctime> //Unix time
+#include <fstream> //File I/O
+#include <iostream> //std I/O
+#include <sstream> //string streams
+#include <string> //string class
+#include <vector> //std vectors
 //#define NDEBUG           //Turns off assert.
 #include <cassert>
 
-
 //=========================Main=========================//
-//nlhs contains the number of LHS (output) arguments and corresponds
-//to the number returned from the Matlab nargout function.  plhs[] is
-//an array of pointers to the output arguments (mxArrays).  nrhs
-//contains the number or RHS (input arguments).  prhs[] is an array of
-//pointers to the input arguments (mxArrays), i.e. prhs[0] points to
-//first input argument, prhs[nrhs-1] to last input argument, etc..
-//When the function is called, prhs contains pointers to the input
-//arguments, while plhs contains null pointers.  Must create output
-//arrays and assign pointers to the plhs pointer array.
-void mexFunction( int nlhs, mxArray *plhs[],
-		  int nrhs, const mxArray *prhs[] )
-{
+// nlhs contains the number of LHS (output) arguments and corresponds
+// to the number returned from the Matlab nargout function.  plhs[] is
+// an array of pointers to the output arguments (mxArrays).  nrhs
+// contains the number or RHS (input arguments).  prhs[] is an array of
+// pointers to the input arguments (mxArrays), i.e. prhs[0] points to
+// first input argument, prhs[nrhs-1] to last input argument, etc..
+// When the function is called, prhs contains pointers to the input
+// arguments, while plhs contains null pointers.  Must create output
+// arrays and assign pointers to the plhs pointer array.
+void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
 
-  //Construct Point to be tested
-  double *in0 = mxGetPr( prhs[0] );
+  // Construct Point to be tested
+  double *in0 = mxGetPr(prhs[0]);
   double test_x = in0[0];
   double test_y = in0[1];
   VisiLibity::Point test_point(test_x, test_y);
 
-
-
-  //Construct environment
-  //Passing structures and cell arrays into MEX-files is just like
-  //passing any other data types, except the data itself is of type
-  //mxArray. In practice, this means that mxGetField (for structures)
-  //and mxGetCell (for cell arrays) return pointers of type
-  //mxArray. You can then treat the pointers like any other pointers
-  //of type mxArray, but if you want to pass the data contained in the
-  //mxArray to a C routine, you must use an API function such as
-  //mxGetData to access it.
+  // Construct environment
+  // Passing structures and cell arrays into MEX-files is just like
+  // passing any other data types, except the data itself is of type
+  // mxArray. In practice, this means that mxGetField (for structures)
+  // and mxGetCell (for cell arrays) return pointers of type
+  // mxArray. You can then treat the pointers like any other pointers
+  // of type mxArray, but if you want to pass the data contained in the
+  // mxArray to a C routine, you must use an API function such as
+  // mxGetData to access it.
   //
-  //Find the dimensions of input
-  //int m = mxGetM(prhs[1]);
-  //int n = mxGetN(prhs[1]);
+  // Find the dimensions of input
+  // int m = mxGetM(prhs[1]);
+  // int n = mxGetN(prhs[1]);
 
-
-  //Auxiliary vars
-  //Recall const My_type *my_ptr => my_ptr points to a constant of
-  //type My_type, i.e., my_ptr is not a constant pointer to a variable
-  //of type My_type.
+  // Auxiliary vars
+  // Recall const My_type *my_ptr => my_ptr points to a constant of
+  // type My_type, i.e., my_ptr is not a constant pointer to a variable
+  // of type My_type.
   const mxArray *polygon_ptr;
   int num_of_coords;
-  //coord_ptr is indexable, e.g., my_coord[0] returns the x
-  //coordinate of the first vertex.
+  // coord_ptr is indexable, e.g., my_coord[0] returns the x
+  // coordinate of the first vertex.
   const double *coord_ptr;
   std::vector<VisiLibity::Point> vertices;
   VisiLibity::Polygon polygon_temp;
 
-
-  //Outer Boundary
+  // Outer Boundary
   polygon_ptr = mxGetCell(prhs[1], 0);
   num_of_coords = mxGetM(polygon_ptr);
-  //mexPrintf("The outer boundary has %i vertices.\n", num_of_coords); 
-  coord_ptr = mxGetPr( polygon_ptr );
-  for(int j=0; j<num_of_coords; j++){
-    vertices.push_back(  VisiLibity::Point( coord_ptr[j],
-					    coord_ptr[num_of_coords + j] )  );
+  // mexPrintf("The outer boundary has %i vertices.\n", num_of_coords);
+  coord_ptr = mxGetPr(polygon_ptr);
+  for (int j = 0; j < num_of_coords; j++) {
+    vertices.push_back(
+        VisiLibity::Point(coord_ptr[j], coord_ptr[num_of_coords + j]));
   }
-  //VisiLibity::Environment my_environment( VisiLibity::Polygon(vertices) );
+  // VisiLibity::Environment my_environment( VisiLibity::Polygon(vertices) );
   polygon_temp.set_vertices(vertices);
   VisiLibity::Environment *my_environment;
   my_environment = new VisiLibity::Environment(polygon_temp);
   vertices.clear();
 
-
-  //Holes  
-  //The number of polygons is the number of cells (one polygon
-  //per cell).
-  int num_of_polygons = mxGetNumberOfElements( prhs[1] );
-  for(int i=1; i<num_of_polygons; i++){
+  // Holes
+  // The number of polygons is the number of cells (one polygon
+  // per cell).
+  int num_of_polygons = mxGetNumberOfElements(prhs[1]);
+  for (int i = 1; i < num_of_polygons; i++) {
 
     polygon_ptr = mxGetCell(prhs[1], i);
     num_of_coords = mxGetM(polygon_ptr);
-    //mexPrintf("The hole #%i has %i vertices.\n", i, num_of_coords); 
-    coord_ptr = mxGetPr( polygon_ptr );
-    for(int j=0; j<num_of_coords; j++){
-      vertices.push_back(  VisiLibity::Point( coord_ptr[j],
-				  coord_ptr[num_of_coords + j] )  );
-    } 
-    
-    polygon_temp.set_vertices( vertices );
-    my_environment->add_hole( polygon_temp );
+    // mexPrintf("The hole #%i has %i vertices.\n", i, num_of_coords);
+    coord_ptr = mxGetPr(polygon_ptr);
+    for (int j = 0; j < num_of_coords; j++) {
+      vertices.push_back(
+          VisiLibity::Point(coord_ptr[j], coord_ptr[num_of_coords + j]));
+    }
+
+    polygon_temp.set_vertices(vertices);
+    my_environment->add_hole(polygon_temp);
     //:COMPILER:
-    //Why doesn't this work if my_environment were not a pointer?
-    //my_environment.add_hole( polygon_temp );
+    // Why doesn't this work if my_environment were not a pointer?
+    // my_environment.add_hole( polygon_temp );
     vertices.clear();
   }
 
-
-  //Get robustness constant
+  // Get robustness constant
   double epsilon = mxGetScalar(prhs[2]);
- 
 
-  //Create an mxArray for the output
-  plhs[0] = mxCreateDoubleMatrix(1, 1, mxREAL );
-  //Create a pointer to output
+  // Create an mxArray for the output
+  plhs[0] = mxCreateDoubleMatrix(1, 1, mxREAL);
+  // Create a pointer to output
   double *out = mxGetPr(plhs[0]);
-  //Populate the output
-  out[0] = static_cast<double>( test_point.in( *my_environment , epsilon ) );
-  
+  // Populate the output
+  out[0] = static_cast<double>(test_point.in(*my_environment, epsilon));
 
   delete my_environment;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,24 +25,23 @@ command line run
 ./main example.environment example.guards
 */
 
-#include "visilibity.hpp"  //VisiLibity header file
-#include <cmath>         //Puts math functions in std namespace
-#include <cstdlib>       //Gives rand, srand, exit
-#include <ctime>         //Gives Unix time
-#include <fstream>       //File I/O
-#include <iostream>      //std I/O
-#include <cstring>       //Gives C-string manipulation
-#include <string>        //Gives string class
-#include <sstream>       //Gives string streams
-#include <vector>        //std vectors
+#include "visilibity.hpp" //VisiLibity header file
+#include <cmath>          //Puts math functions in std namespace
+#include <cstdlib>        //Gives rand, srand, exit
+#include <cstring>        //Gives C-string manipulation
+#include <ctime>          //Gives Unix time
+#include <fstream>        //File I/O
+#include <iostream>       //std I/O
+#include <sstream>        //Gives string streams
+#include <string>         //Gives string class
+#include <vector>         //std vectors
 //#define NDEBUG           //Turns off assert.
 #include <cassert>
 
-
-//ASCII escape sequences for colored terminal text.
-std::string alert("\a");       //Beep
-std::string normal("\x1b[0m"); //Designated fg color default bg color
-std::string red("\x1b[31m");         
+// ASCII escape sequences for colored terminal text.
+std::string alert("\a");       // Beep
+std::string normal("\x1b[0m"); // Designated fg color default bg color
+std::string red("\x1b[31m");
 std::string red_blink("\x1b[5;31m");
 std::string black("\E[30;47m");
 std::string green("\E[32m");
@@ -52,161 +51,136 @@ std::string magenta("\x1b[35m");
 std::string cyan("\E[36m");
 std::string white_bold("\E[1;37;40m");
 std::string clear_display("\E[2J");
-  
 
 //=========================Main=========================//
-int main(int argc, char *argv[])
-{
+int main(int argc, char *argv[]) {
 
-  //Check input validity
-  if(argc > 3){
+  // Check input validity
+  if (argc > 3) {
     std::cerr << "Error: too many input arguments" << std::endl;
     exit(1);
   }
 
-
-  //Set iostream floating-point display format
+  // Set iostream floating-point display format
   const int IOS_PRECISION = 10;
   std::cout.setf(std::ios::fixed);
   std::cout.setf(std::ios::showpoint);
   std::cout.precision(IOS_PRECISION);
 
-
-  //Seed the rand() fnc w/Unix time
+  // Seed the rand() fnc w/Unix time
   //(only necessary once at the beginning of the program)
-  std::srand( std::time( NULL ) ); rand();
+  std::srand(std::time(NULL));
+  rand();
 
-
-  //Set geometric robustness constant
-  //:WARNING: 
-  //may need to modify epsilon for Environments with greatly varying
-  //scale of features
+  // Set geometric robustness constant
+  //:WARNING:
+  // may need to modify epsilon for Environments with greatly varying
+  // scale of features
   double epsilon = 0.000000001;
-  std::cout << green << "The robustness constant epsilon is set to "
-	    << epsilon << normal << std::endl;
-
+  std::cout << green << "The robustness constant epsilon is set to " << epsilon
+            << normal << std::endl;
 
   /*----------Load Geometry from Files----------*/
 
-
-  //Load geometric environment model from file
+  // Load geometric environment model from file
   std::cout << "Loading environment file ";
   std::string environment_file(argv[1]);
-  //Print environment filename to screen
+  // Print environment filename to screen
   std::cout << environment_file << " . . . ";
-  //Construct Environment object from file
+  // Construct Environment object from file
   VisiLibity::Environment my_environment(environment_file);
   std::cout << "OK" << std::endl;
 
-
-  //Load guard positions from file
+  // Load guard positions from file
   std::cout << "Loading guards file ";
   std::string guards_file(argv[2]);
-  //Print guards filename to screen
+  // Print guards filename to screen
   std::cout << guards_file << " . . . ";
-  //Construct Guards object from file
+  // Construct Guards object from file
   VisiLibity::Guards my_guards(guards_file);
   std::cout << "OK" << std::endl;
 
-
   /*----------Check Validity of Geometry----------*/
 
-
-  //Check Environment is epsilon-valid
+  // Check Environment is epsilon-valid
   std::cout << "Validating environment model . . . ";
-  if(  my_environment.is_valid( epsilon )  )
+  if (my_environment.is_valid(epsilon))
     std::cout << "OK" << std::endl;
-  else{
-    std::cout << std::endl << red << "Warning:  Environment model "
-	      << "is invalid." << std::endl
-	      << "A valid environment model must have" << std::endl
-	      << "   1) outer boundary and holes pairwise "
-	      << "epsilon -disjoint simple polygons" << std::endl
-	      << "   (no two features should come "
-	      << "within epsilon of each other)," << std::endl 
-	      << "   2) outer boundary is oriented ccw, and" 
-	      << std::endl
-	      << "   3) holes are oriented cw."
-	      << std::endl
-	      << normal; 
+  else {
+    std::cout << std::endl
+              << red << "Warning:  Environment model "
+              << "is invalid." << std::endl
+              << "A valid environment model must have" << std::endl
+              << "   1) outer boundary and holes pairwise "
+              << "epsilon -disjoint simple polygons" << std::endl
+              << "   (no two features should come "
+              << "within epsilon of each other)," << std::endl
+              << "   2) outer boundary is oriented ccw, and" << std::endl
+              << "   3) holes are oriented cw." << std::endl
+              << normal;
     exit(1);
   }
 
-
-  //Check Guards are all in the Environment
+  // Check Guards are all in the Environment
   std::cout << "Checking all guards are "
-	    << "in the environment and noncolocated . . . ";
+            << "in the environment and noncolocated . . . ";
   my_guards.snap_to_boundary_of(my_environment, epsilon);
   my_guards.snap_to_vertices_of(my_environment, epsilon);
-  for(unsigned i=0; i<my_guards.N(); i++){
-    if( !my_guards[i].in(my_environment, epsilon) ){
-      std::cout << std::endl << red 
-		<< "Warning:  guard " << i 
-		<< " not in the environment."
-		<< normal << std::endl;
+  for (unsigned i = 0; i < my_guards.N(); i++) {
+    if (!my_guards[i].in(my_environment, epsilon)) {
+      std::cout << std::endl
+                << red << "Warning:  guard " << i << " not in the environment."
+                << normal << std::endl;
       exit(1);
     }
   }
-  if( !my_guards.noncolocated(epsilon) ){
-    std::cout << std::endl << red 
-	      << "Warning:  Some guards are colocated." 
-	      <<  normal << std::endl;
+  if (!my_guards.noncolocated(epsilon)) {
+    std::cout << std::endl
+              << red << "Warning:  Some guards are colocated." << normal
+              << std::endl;
     exit(1);
-  }
-  else
+  } else
     std::cout << "OK" << std::endl;
-
-
 
   /*----------Print Data and Statistics to Screen----------*/
 
-
-  //Environment data
+  // Environment data
   std::cout << "The environment model is:" << std::endl;
   std::cout << magenta << my_environment << normal;
 
+  // Environment stats
+  std::cout << "This environment has " << cyan << my_environment.n()
+            << " vertices, " << my_environment.r() << " reflex vertices, "
+            << my_environment.h() << " holes, "
+            << "area " << my_environment.area() << ", "
+            << "boundary length " << my_environment.boundary_length() << ", "
+            << "diameter " << my_environment.diameter() << "." << normal
+            << std::endl;
 
-  //Environment stats
-  std::cout << "This environment has " << cyan 
-	    << my_environment.n() << " vertices, " 
-	    << my_environment.r() << " reflex vertices, " 
-	    << my_environment.h() << " holes, "
-	    << "area " << my_environment.area() << ", "
-	    << "boundary length " 
-	    << my_environment.boundary_length() << ", "
-	    << "diameter " 
-	    << my_environment.diameter() << "."
-	    << normal << std::endl;
-
-
-  //Guards data
+  // Guards data
   std::cout << "The guards' positions are:" << std::endl;
   std::cout << magenta << my_guards << normal;
 
+  // Guards stats
+  std::cout << "There are " << cyan << my_guards.N() << " guards." << normal
+            << std::endl;
 
-  //Guards stats
-  std::cout << "There are " << cyan << my_guards.N() 
-	    << " guards." << normal << std::endl;
-
-
-  /*----------Compute the Visibility Polygon 
+  /*----------Compute the Visibility Polygon
                    of a Guard Chosen by User----------*/
- 
- 
-  //Prompt user
+
+  // Prompt user
   int guard_choice(0);
   std::cout << "Which guard would you like "
-	    <<"to compute the visibility polygon of "
-	    << "(0, 1, 2, ...)? " << std::endl;
-  std::cin >> guard_choice; std::cout << normal;
+            << "to compute the visibility polygon of "
+            << "(0, 1, 2, ...)? " << std::endl;
+  std::cin >> guard_choice;
+  std::cout << normal;
 
-	 
-  //Compute and display visibility polygon
-  VisiLibity::Visibility_Polygon
-    my_visibility_polygon(my_guards[guard_choice], my_environment, epsilon);
+  // Compute and display visibility polygon
+  VisiLibity::Visibility_Polygon my_visibility_polygon(my_guards[guard_choice],
+                                                       my_environment, epsilon);
   std::cout << "The visibility polygon is" << std::endl
-	    << magenta << my_visibility_polygon << normal
-	    << std::endl;
+            << magenta << my_visibility_polygon << normal << std::endl;
 
   /*
   //To save the visibility polygon in an Environment file

--- a/src/shortest_path.cpp
+++ b/src/shortest_path.cpp
@@ -19,163 +19,148 @@ environment is a cell array of the environment vertices
 (x and y coordinates),
 epsilon is a double (the robustness constant), and
 snap_distance is a double representing the largest distance at which
-the start and finish Poinst will still be snapped to the vertices and 
+the start and finish Poinst will still be snapped to the vertices and
 boundary of the environment.
 */
 
-
-//Gives Matlab interfacing.  Linkage block specifies linkage
-//convention used to link header file; makes the C header suitable for
-//C++ use.  "mex.h" also includes "matrix.h" to provide MX functions
-//to support Matlab data types, along with the standard header files
+// Gives Matlab interfacing.  Linkage block specifies linkage
+// convention used to link header file; makes the C header suitable for
+// C++ use.  "mex.h" also includes "matrix.h" to provide MX functions
+// to support Matlab data types, along with the standard header files
 //<stdio.h>, <stdlib.h>, and <stddef.h>.
 extern "C" {
-#include <math.h>
 #include "mex.h"
+#include <math.h>
 }
 
-
-#include "visilibity.hpp"  //VisiLibity header file
+#include "visilibity.hpp" //VisiLibity header file
 //#include <cmath>         //Puts math functions in std namespace
-#include <cstdlib>       //rand, srand, exit
-#include <ctime>         //Unix time
-#include <fstream>       //File I/O
-#include <iostream>      //std I/O
-#include <cstring>       //C-string manipulation
-#include <string>        //string class
-#include <sstream>       //string streams
-#include <vector>        //std vectors
+#include <cstdlib> //rand, srand, exit
+#include <cstring> //C-string manipulation
+#include <ctime> //Unix time
+#include <fstream> //File I/O
+#include <iostream> //std I/O
+#include <sstream> //string streams
+#include <string> //string class
+#include <vector> //std vectors
 //#define NDEBUG           //Turns off assert.
 #include <cassert>
 
-
 //=========================Main=========================//
-//nlhs contains the number of LHS (output) arguments and corresponds
-//to the number returned from the Matlab nargout function.  plhs[] is
-//an array of pointers to the output arguments (mxArrays).  nrhs
-//contains the number or RHS (input arguments).  prhs[] is an array of
-//pointers to the input arguments (mxArrays), i.e. prhs[0] points to
-//first input argument, prhs[nrhs-1] to last input argument, etc..
-//When the function is called, prhs contains pointers to the input
-//arguments, while plhs contains null pointers.  Must create output
-//arrays and assign pointers to the plhs pointer array.
-void mexFunction( int nlhs, mxArray *plhs[],
-		  int nrhs, const mxArray *prhs[] )
-{
+// nlhs contains the number of LHS (output) arguments and corresponds
+// to the number returned from the Matlab nargout function.  plhs[] is
+// an array of pointers to the output arguments (mxArrays).  nrhs
+// contains the number or RHS (input arguments).  prhs[] is an array of
+// pointers to the input arguments (mxArrays), i.e. prhs[0] points to
+// first input argument, prhs[nrhs-1] to last input argument, etc..
+// When the function is called, prhs contains pointers to the input
+// arguments, while plhs contains null pointers.  Must create output
+// arrays and assign pointers to the plhs pointer array.
+void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
 
-  //Construct the start Point
-  double *in0 = mxGetPr( prhs[0] );
+  // Construct the start Point
+  double *in0 = mxGetPr(prhs[0]);
   double start_x = in0[0];
   double start_y = in0[1];
   VisiLibity::Point start(start_x, start_y);
 
-
-  //Construct the finish Point
-  double *in1 = mxGetPr( prhs[1] );
+  // Construct the finish Point
+  double *in1 = mxGetPr(prhs[1]);
   double finish_x = in1[0];
   double finish_y = in1[1];
   VisiLibity::Point finish(finish_x, finish_y);
 
-
-  //Construct environment
-  //Passing structures and cell arrays into MEX-files is just like
-  //passing any other data types, except the data itself is of type
-  //mxArray. In practice, this means that mxGetField (for structures)
-  //and mxGetCell (for cell arrays) return pointers of type
-  //mxArray. You can then treat the pointers like any other pointers
-  //of type mxArray, but if you want to pass the data contained in the
-  //mxArray to a C routine, you must use an API function such as
-  //mxGetData to access it.
+  // Construct environment
+  // Passing structures and cell arrays into MEX-files is just like
+  // passing any other data types, except the data itself is of type
+  // mxArray. In practice, this means that mxGetField (for structures)
+  // and mxGetCell (for cell arrays) return pointers of type
+  // mxArray. You can then treat the pointers like any other pointers
+  // of type mxArray, but if you want to pass the data contained in the
+  // mxArray to a C routine, you must use an API function such as
+  // mxGetData to access it.
   //
-  //Find the dimensions of input
-  //int m = mxGetM(prhs[1]);
-  //int n = mxGetN(prhs[1]);
+  // Find the dimensions of input
+  // int m = mxGetM(prhs[1]);
+  // int n = mxGetN(prhs[1]);
 
-
-  //Auxiliary vars
-  //Recall const My_type *my_ptr => my_ptr points to a constant of
-  //type My_type, i.e., my_ptr is not a constant pointer to a variable
-  //of type My_type.
+  // Auxiliary vars
+  // Recall const My_type *my_ptr => my_ptr points to a constant of
+  // type My_type, i.e., my_ptr is not a constant pointer to a variable
+  // of type My_type.
   const mxArray *polygon_ptr;
   int num_of_coords;
-  //coord_ptr is indexable, e.g., my_coord[0] returns the x
-  //coordinate of the first vertex.
+  // coord_ptr is indexable, e.g., my_coord[0] returns the x
+  // coordinate of the first vertex.
   const double *coord_ptr;
   std::vector<VisiLibity::Point> vertices;
   VisiLibity::Polygon polygon_temp;
 
-
-  //Outer Boundary
+  // Outer Boundary
   polygon_ptr = mxGetCell(prhs[2], 0);
   num_of_coords = mxGetM(polygon_ptr);
-  //mexPrintf("The outer boundary has %i vertices.\n", num_of_coords); 
-  coord_ptr = mxGetPr( polygon_ptr );
-  for(int j=0; j<num_of_coords; j++){
-    vertices.push_back(  VisiLibity::Point( coord_ptr[j],
-					    coord_ptr[num_of_coords + j] )  );
+  // mexPrintf("The outer boundary has %i vertices.\n", num_of_coords);
+  coord_ptr = mxGetPr(polygon_ptr);
+  for (int j = 0; j < num_of_coords; j++) {
+    vertices.push_back(
+        VisiLibity::Point(coord_ptr[j], coord_ptr[num_of_coords + j]));
   }
-  //VisiLibity::Environment my_environment( VisiLibity::Polygon(vertices) );
+  // VisiLibity::Environment my_environment( VisiLibity::Polygon(vertices) );
   polygon_temp.set_vertices(vertices);
   VisiLibity::Environment *my_environment;
   my_environment = new VisiLibity::Environment(polygon_temp);
   vertices.clear();
 
-
-  //Holes  
-  //The number of polygons is the number of cells (one polygon
-  //per cell).
-  int num_of_polygons = mxGetNumberOfElements( prhs[2] );
-  for(int i=1; i<num_of_polygons; i++){
+  // Holes
+  // The number of polygons is the number of cells (one polygon
+  // per cell).
+  int num_of_polygons = mxGetNumberOfElements(prhs[2]);
+  for (int i = 1; i < num_of_polygons; i++) {
 
     polygon_ptr = mxGetCell(prhs[2], i);
     num_of_coords = mxGetM(polygon_ptr);
-    //mexPrintf("The hole #%i has %i vertices.\n", i, num_of_coords); 
-    coord_ptr = mxGetPr( polygon_ptr );
-    for(int j=0; j<num_of_coords; j++){
-      vertices.push_back(  VisiLibity::Point( coord_ptr[j],
-				  coord_ptr[num_of_coords + j] )  );
-    } 
-    
-    polygon_temp.set_vertices( vertices );
-    my_environment->add_hole( polygon_temp );
+    // mexPrintf("The hole #%i has %i vertices.\n", i, num_of_coords);
+    coord_ptr = mxGetPr(polygon_ptr);
+    for (int j = 0; j < num_of_coords; j++) {
+      vertices.push_back(
+          VisiLibity::Point(coord_ptr[j], coord_ptr[num_of_coords + j]));
+    }
+
+    polygon_temp.set_vertices(vertices);
+    my_environment->add_hole(polygon_temp);
     //:COMPILER:
-    //Why doesn't this work if my_environment were not a pointer?
-    //my_environment.add_hole( polygon_temp );
+    // Why doesn't this work if my_environment were not a pointer?
+    // my_environment.add_hole( polygon_temp );
     vertices.clear();
   }
 
-
-  //Get robustness constant
+  // Get robustness constant
   double epsilon = mxGetScalar(prhs[3]);
- 
-  
-  //Adjust start and finish location according to snap distance
+
+  // Adjust start and finish location according to snap distance
   double snap_distance = mxGetScalar(prhs[4]);
-  if(  !start.in( *my_environment , epsilon )  )
-    start = start.projection_onto_boundary_of( *my_environment );
-  start.snap_to_boundary_of( (*my_environment) , snap_distance);
-  start.snap_to_vertices_of( (*my_environment) , snap_distance);
-  if(  !finish.in( *my_environment , epsilon )  )
-    finish = finish.projection_onto_boundary_of( *my_environment );
-  finish.snap_to_boundary_of( (*my_environment) , snap_distance);
-  finish.snap_to_vertices_of( (*my_environment) , snap_distance);
+  if (!start.in(*my_environment, epsilon))
+    start = start.projection_onto_boundary_of(*my_environment);
+  start.snap_to_boundary_of((*my_environment), snap_distance);
+  start.snap_to_vertices_of((*my_environment), snap_distance);
+  if (!finish.in(*my_environment, epsilon))
+    finish = finish.projection_onto_boundary_of(*my_environment);
+  finish.snap_to_boundary_of((*my_environment), snap_distance);
+  finish.snap_to_vertices_of((*my_environment), snap_distance);
 
-
-  //Compute shortest path through environment from start to finish
+  // Compute shortest path through environment from start to finish
   VisiLibity::Polyline my_shortest_path;
   my_shortest_path = my_environment->shortest_path(start, finish, epsilon);
 
-  
-  //Create an mxArray for the output
-  plhs[0] = mxCreateDoubleMatrix( my_shortest_path.size(), 2, mxREAL );
-  //Create a pointer to output
+  // Create an mxArray for the output
+  plhs[0] = mxCreateDoubleMatrix(my_shortest_path.size(), 2, mxREAL);
+  // Create a pointer to output
   double *out = mxGetPr(plhs[0]);
-  //Populate the output
-  for (int i=0; i<my_shortest_path.size(); i++){
-    out[i]                           = my_shortest_path[i].x();
+  // Populate the output
+  for (int i = 0; i < my_shortest_path.size(); i++) {
+    out[i] = my_shortest_path[i].x();
     out[my_shortest_path.size() + i] = my_shortest_path[i].y();
   }
- 
 
   delete my_environment;
 

--- a/src/visibility_graph.cpp
+++ b/src/visibility_graph.cpp
@@ -19,146 +19,130 @@ environment is a cell array of the environment vertices
 epsilon is a double (the robustness constant).
 */
 
-
-//Gives Matlab interfacing.  Linkage block specifies linkage
-//convention used to link header file; makes the C header suitable for
-//C++ use.  "mex.h" also includes "matrix.h" to provide MX functions
-//to support Matlab data types, along with the standard header files
+// Gives Matlab interfacing.  Linkage block specifies linkage
+// convention used to link header file; makes the C header suitable for
+// C++ use.  "mex.h" also includes "matrix.h" to provide MX functions
+// to support Matlab data types, along with the standard header files
 //<stdio.h>, <stdlib.h>, and <stddef.h>.
 extern "C" {
-#include <math.h>
 #include "mex.h"
+#include <math.h>
 }
 
-
-#include "visilibity.hpp"  //VisiLibity header file
+#include "visilibity.hpp" //VisiLibity header file
 //#include <cmath>         //Puts math functions in std namespace
-#include <cstdlib>       //rand, srand, exit
-#include <ctime>         //Unix time
-#include <fstream>       //File I/O
-#include <iostream>      //std I/O
-#include <cstring>       //C-string manipulation
-#include <string>        //string class
-#include <sstream>       //string streams
-#include <vector>        //std vectors
+#include <cstdlib> //rand, srand, exit
+#include <cstring> //C-string manipulation
+#include <ctime> //Unix time
+#include <fstream> //File I/O
+#include <iostream> //std I/O
+#include <sstream> //string streams
+#include <string> //string class
+#include <vector> //std vectors
 //#define NDEBUG           //Turns off assert.
 #include <cassert>
 
-
 //=========================Main=========================//
-//nlhs contains the number of LHS (output) arguments and corresponds
-//to the number returned from the Matlab nargout function.  plhs[] is
-//an array of pointers to the output arguments (mxArrays).  nrhs
-//contains the number or RHS (input arguments).  prhs[] is an array of
-//pointers to the input arguments (mxArrays), i.e. prhs[0] points to
-//first input argument, prhs[nrhs-1] to last input argument, etc..
-//When the function is called, prhs contains pointers to the input
-//arguments, while plhs contains null pointers.  Must create output
-//arrays and assign pointers to the plhs pointer array.
-void mexFunction( int nlhs, mxArray *plhs[],
-		  int nrhs, const mxArray *prhs[] )
-{
+// nlhs contains the number of LHS (output) arguments and corresponds
+// to the number returned from the Matlab nargout function.  plhs[] is
+// an array of pointers to the output arguments (mxArrays).  nrhs
+// contains the number or RHS (input arguments).  prhs[] is an array of
+// pointers to the input arguments (mxArrays), i.e. prhs[0] points to
+// first input argument, prhs[nrhs-1] to last input argument, etc..
+// When the function is called, prhs contains pointers to the input
+// arguments, while plhs contains null pointers.  Must create output
+// arrays and assign pointers to the plhs pointer array.
+void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
 
-  //Construct Guards
+  // Construct Guards
   std::vector<VisiLibity::Point> guards;
-  VisiLibity::Point  guard;
-  double *in0       = mxGetPr( prhs[0] );
-  int num_of_guards =  mxGetM( prhs[0] );
-  for (int i=0; i<num_of_guards; i++){
-    guard.set_x( in0[i] ); guard.set_y( in0[num_of_guards+i] );
-    guards.push_back( guard );
+  VisiLibity::Point guard;
+  double *in0 = mxGetPr(prhs[0]);
+  int num_of_guards = mxGetM(prhs[0]);
+  for (int i = 0; i < num_of_guards; i++) {
+    guard.set_x(in0[i]);
+    guard.set_y(in0[num_of_guards + i]);
+    guards.push_back(guard);
   }
-  
 
-  //Construct Environment
-  //Passing structures and cell arrays into MEX-files is just like
-  //passing any other data types, except the data itself is of type
-  //mxArray. In practice, this means that mxGetField (for structures)
-  //and mxGetCell (for cell arrays) return pointers of type
-  //mxArray. You can then treat the pointers like any other pointers
-  //of type mxArray, but if you want to pass the data contained in the
-  //mxArray to a C routine, you must use an API function such as
-  //mxGetData to access it.
+  // Construct Environment
+  // Passing structures and cell arrays into MEX-files is just like
+  // passing any other data types, except the data itself is of type
+  // mxArray. In practice, this means that mxGetField (for structures)
+  // and mxGetCell (for cell arrays) return pointers of type
+  // mxArray. You can then treat the pointers like any other pointers
+  // of type mxArray, but if you want to pass the data contained in the
+  // mxArray to a C routine, you must use an API function such as
+  // mxGetData to access it.
   //
-  //Find the dimensions of input.
-  //int m = mxGetM(prhs[1]);
-  //int n = mxGetN(prhs[1]);
+  // Find the dimensions of input.
+  // int m = mxGetM(prhs[1]);
+  // int n = mxGetN(prhs[1]);
 
-
-  //Auxiliary vars
-  //Recall const My_type *my_ptr => my_ptr points to a constant of
-  //type My_type, i.e., my_ptr is not a constant pointer to a variable
-  //of type My_type.
+  // Auxiliary vars
+  // Recall const My_type *my_ptr => my_ptr points to a constant of
+  // type My_type, i.e., my_ptr is not a constant pointer to a variable
+  // of type My_type.
   const mxArray *polygon_ptr;
   int num_of_coords;
-  //coord_ptr is indexable, e.g., my_coord[0] returns the x
-  //coordinate of the first vertex.
+  // coord_ptr is indexable, e.g., my_coord[0] returns the x
+  // coordinate of the first vertex.
   const double *coord_ptr;
   std::vector<VisiLibity::Point> vertices;
   VisiLibity::Polygon polygon_temp;
 
-
-  //Outer Boundary
+  // Outer Boundary
   polygon_ptr = mxGetCell(prhs[1], 0);
   num_of_coords = mxGetM(polygon_ptr);
-  //mexPrintf("The outer boundary has %i vertices.\n", num_of_coords); 
-  coord_ptr = mxGetPr( polygon_ptr );
-  for(int j=0; j<num_of_coords; j++){
-    vertices.push_back(  VisiLibity::Point( coord_ptr[j],
-					    coord_ptr[num_of_coords + j] )  );
+  // mexPrintf("The outer boundary has %i vertices.\n", num_of_coords);
+  coord_ptr = mxGetPr(polygon_ptr);
+  for (int j = 0; j < num_of_coords; j++) {
+    vertices.push_back(
+        VisiLibity::Point(coord_ptr[j], coord_ptr[num_of_coords + j]));
   }
-  //VisiLibity::Environment my_environment( VisiLibity::Polygon(vertices) );
+  // VisiLibity::Environment my_environment( VisiLibity::Polygon(vertices) );
   polygon_temp.set_vertices(vertices);
   VisiLibity::Environment *my_environment;
   my_environment = new VisiLibity::Environment(polygon_temp);
   vertices.clear();
 
-
-  //Holes
-  //The number of polygons is the number of cells (one polygon
-  //per cell).
-  int num_of_polygons = mxGetNumberOfElements( prhs[1] );
-  for(int i=1; i<num_of_polygons; i++){
+  // Holes
+  // The number of polygons is the number of cells (one polygon
+  // per cell).
+  int num_of_polygons = mxGetNumberOfElements(prhs[1]);
+  for (int i = 1; i < num_of_polygons; i++) {
 
     polygon_ptr = mxGetCell(prhs[1], i);
     num_of_coords = mxGetM(polygon_ptr);
-    //mexPrintf("The hole #%i has %i vertices.\n", i, num_of_coords); 
-    coord_ptr = mxGetPr( polygon_ptr );
-    for(int j=0; j<num_of_coords; j++){
-      vertices.push_back(  VisiLibity::Point( coord_ptr[j],
-				  coord_ptr[num_of_coords + j] )  );
-    } 
-    
-    polygon_temp.set_vertices( vertices );
-    my_environment->add_hole( polygon_temp );
+    // mexPrintf("The hole #%i has %i vertices.\n", i, num_of_coords);
+    coord_ptr = mxGetPr(polygon_ptr);
+    for (int j = 0; j < num_of_coords; j++) {
+      vertices.push_back(
+          VisiLibity::Point(coord_ptr[j], coord_ptr[num_of_coords + j]));
+    }
+
+    polygon_temp.set_vertices(vertices);
+    my_environment->add_hole(polygon_temp);
     //:COMPILER:
-    //Why doesn't this work if my_environment were not a pointer?
-    //my_environment.add_hole( polygon_temp );
+    // Why doesn't this work if my_environment were not a pointer?
+    // my_environment.add_hole( polygon_temp );
     vertices.clear();
   }
 
-
-  //Get robustness constant
+  // Get robustness constant
   double epsilon = mxGetScalar(prhs[2]);
- 
 
-  //Compute Visibility_Graph
-  VisiLibity::Visibility_Graph my_vis_graph( guards,
-					     (*my_environment),
-					     epsilon );
+  // Compute Visibility_Graph
+  VisiLibity::Visibility_Graph my_vis_graph(guards, (*my_environment), epsilon);
 
-
-  //Create an mxArray for the output
-  plhs[0] = mxCreateDoubleMatrix( guards.size(),
-				  guards.size(),
-				  mxREAL );
-  //Create a pointer to output
+  // Create an mxArray for the output
+  plhs[0] = mxCreateDoubleMatrix(guards.size(), guards.size(), mxREAL);
+  // Create a pointer to output
   double *out = mxGetPr(plhs[0]);
-  //Populate the output
-  for (int i=0; i<guards.size(); i++)
-    for (int j=0; j<guards.size(); j++)
-      out[i + guards.size()*j] = my_vis_graph(i,j);
- 
+  // Populate the output
+  for (int i = 0; i < guards.size(); i++)
+    for (int j = 0; j < guards.size(); j++)
+      out[i + guards.size() * j] = my_vis_graph(i, j);
 
   delete my_environment;
 

--- a/src/visibility_polygon.cpp
+++ b/src/visibility_polygon.cpp
@@ -17,154 +17,139 @@ environment is a cell array of the environment vertices
 (x and y coordinates),
 epsilon is a double (the robustness constant), and
 snap_distance is a double representing the largest distance at which
-the observer will still be snapped to the vertices and boundary of 
+the observer will still be snapped to the vertices and boundary of
 the environment.
 */
 
-
-//Gives Matlab interfacing.  Linkage block specifies linkage
-//convention used to link header file; makes the C header suitable for
-//C++ use.  "mex.h" also includes "matrix.h" to provide MX functions
-//to support Matlab data types, along with the standard header files
+// Gives Matlab interfacing.  Linkage block specifies linkage
+// convention used to link header file; makes the C header suitable for
+// C++ use.  "mex.h" also includes "matrix.h" to provide MX functions
+// to support Matlab data types, along with the standard header files
 //<stdio.h>, <stdlib.h>, and <stddef.h>.
 extern "C" {
-#include <math.h>
 #include "mex.h"
+#include <math.h>
 }
 
-
-#include "visilibity.hpp"  //VisiLibity header file
+#include "visilibity.hpp" //VisiLibity header file
 //#include <cmath>         //Puts math functions in std namespace
-#include <cstdlib>       //rand, srand, exit
-#include <ctime>         //Unix time
-#include <fstream>       //File I/O
-#include <iostream>      //std I/O
-#include <cstring>       //C-string manipulation
-#include <string>        //string class
-#include <sstream>       //string streams
-#include <vector>        //std vectors
+#include <cstdlib> //rand, srand, exit
+#include <cstring> //C-string manipulation
+#include <ctime> //Unix time
+#include <fstream> //File I/O
+#include <iostream> //std I/O
+#include <sstream> //string streams
+#include <string> //string class
+#include <vector> //std vectors
 //#define NDEBUG           //Turns off assert.
 #include <cassert>
 
-
 //=========================Main=========================//
-//nlhs contains the number of LHS (output) arguments and corresponds
-//to the number returned from the Matlab nargout function.  plhs[] is
-//an array of pointers to the output arguments (mxArrays).  nrhs
-//contains the number or RHS (input arguments).  prhs[] is an array of
-//pointers to the input arguments (mxArrays), i.e. prhs[0] points to
-//first input argument, prhs[nrhs-1] to last input argument, etc..
-//When the function is called, prhs contains pointers to the input
-//arguments, while plhs contains null pointers.  Must create output
-//arrays and assign pointers to the plhs pointer array.
-void mexFunction( int nlhs, mxArray *plhs[],
-		  int nrhs, const mxArray *prhs[] )
-{
+// nlhs contains the number of LHS (output) arguments and corresponds
+// to the number returned from the Matlab nargout function.  plhs[] is
+// an array of pointers to the output arguments (mxArrays).  nrhs
+// contains the number or RHS (input arguments).  prhs[] is an array of
+// pointers to the input arguments (mxArrays), i.e. prhs[0] points to
+// first input argument, prhs[nrhs-1] to last input argument, etc..
+// When the function is called, prhs contains pointers to the input
+// arguments, while plhs contains null pointers.  Must create output
+// arrays and assign pointers to the plhs pointer array.
+void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
 
-  //Construct Point where observer located
-  double *in0 = mxGetPr( prhs[0] );
+  // Construct Point where observer located
+  double *in0 = mxGetPr(prhs[0]);
   double observer_x = in0[0];
   double observer_y = in0[1];
   VisiLibity::Point observer(observer_x, observer_y);
 
-
-  //Construct environment
-  //Passing structures and cell arrays into MEX-files is just like
-  //passing any other data types, except the data itself is of type
-  //mxArray. In practice, this means that mxGetField (for structures)
-  //and mxGetCell (for cell arrays) return pointers of type
-  //mxArray. You can then treat the pointers like any other pointers
-  //of type mxArray, but if you want to pass the data contained in the
-  //mxArray to a C routine, you must use an API function such as
-  //mxGetData to access it.
+  // Construct environment
+  // Passing structures and cell arrays into MEX-files is just like
+  // passing any other data types, except the data itself is of type
+  // mxArray. In practice, this means that mxGetField (for structures)
+  // and mxGetCell (for cell arrays) return pointers of type
+  // mxArray. You can then treat the pointers like any other pointers
+  // of type mxArray, but if you want to pass the data contained in the
+  // mxArray to a C routine, you must use an API function such as
+  // mxGetData to access it.
   //
-  //Find the dimensions of input.
-  //int m = mxGetM(prhs[1]);
-  //int n = mxGetN(prhs[1]);
+  // Find the dimensions of input.
+  // int m = mxGetM(prhs[1]);
+  // int n = mxGetN(prhs[1]);
 
-
-  //Auxiliary vars
-  //Recall const My_type *my_ptr => my_ptr points to a constant of
-  //type My_type, i.e., my_ptr is not a constant pointer to a variable
-  //of type My_type.
+  // Auxiliary vars
+  // Recall const My_type *my_ptr => my_ptr points to a constant of
+  // type My_type, i.e., my_ptr is not a constant pointer to a variable
+  // of type My_type.
   const mxArray *polygon_ptr;
   int num_of_coords;
-  //coord_ptr is indexable, e.g., my_coord[0] returns the x
-  //coordinate of the first vertex.
+  // coord_ptr is indexable, e.g., my_coord[0] returns the x
+  // coordinate of the first vertex.
   const double *coord_ptr;
   std::vector<VisiLibity::Point> vertices;
   VisiLibity::Polygon polygon_temp;
 
-
-  //Outer Boundary
+  // Outer Boundary
   polygon_ptr = mxGetCell(prhs[1], 0);
   num_of_coords = mxGetM(polygon_ptr);
-  //mexPrintf("The outer boundary has %i vertices.\n", num_of_coords); 
-  coord_ptr = mxGetPr( polygon_ptr );
-  for(int j=0; j<num_of_coords; j++){
-    vertices.push_back(  VisiLibity::Point( coord_ptr[j],
-					    coord_ptr[num_of_coords + j] )  );
+  // mexPrintf("The outer boundary has %i vertices.\n", num_of_coords);
+  coord_ptr = mxGetPr(polygon_ptr);
+  for (int j = 0; j < num_of_coords; j++) {
+    vertices.push_back(
+        VisiLibity::Point(coord_ptr[j], coord_ptr[num_of_coords + j]));
   }
-  //VisiLibity::Environment my_environment( VisiLibity::Polygon(vertices) );
+  // VisiLibity::Environment my_environment( VisiLibity::Polygon(vertices) );
   polygon_temp.set_vertices(vertices);
   VisiLibity::Environment *my_environment;
   my_environment = new VisiLibity::Environment(polygon_temp);
   vertices.clear();
 
-
-  //Holes
-  //The number of polygons is the number of cells (one polygon
-  //per cell).
-  int num_of_polygons = mxGetNumberOfElements( prhs[1] );
-  for(int i=1; i<num_of_polygons; i++){
+  // Holes
+  // The number of polygons is the number of cells (one polygon
+  // per cell).
+  int num_of_polygons = mxGetNumberOfElements(prhs[1]);
+  for (int i = 1; i < num_of_polygons; i++) {
 
     polygon_ptr = mxGetCell(prhs[1], i);
     num_of_coords = mxGetM(polygon_ptr);
-    //mexPrintf("The hole #%i has %i vertices.\n", i, num_of_coords); 
-    coord_ptr = mxGetPr( polygon_ptr );
-    for(int j=0; j<num_of_coords; j++){
-      vertices.push_back(  VisiLibity::Point( coord_ptr[j],
-				  coord_ptr[num_of_coords + j] )  );
-    } 
-    
-    polygon_temp.set_vertices( vertices );
-    my_environment->add_hole( polygon_temp );
+    // mexPrintf("The hole #%i has %i vertices.\n", i, num_of_coords);
+    coord_ptr = mxGetPr(polygon_ptr);
+    for (int j = 0; j < num_of_coords; j++) {
+      vertices.push_back(
+          VisiLibity::Point(coord_ptr[j], coord_ptr[num_of_coords + j]));
+    }
+
+    polygon_temp.set_vertices(vertices);
+    my_environment->add_hole(polygon_temp);
     //:COMPILER:
-    //Why doesn't this work if my_environment were not a pointer?
-    //my_environment.add_hole( polygon_temp );
+    // Why doesn't this work if my_environment were not a pointer?
+    // my_environment.add_hole( polygon_temp );
     vertices.clear();
   }
 
-
-  //Get robustness constant
+  // Get robustness constant
   double epsilon = mxGetScalar(prhs[2]);
- 
 
-  //Adjust observer location according to snap distance
+  // Adjust observer location according to snap distance
   double snap_distance = mxGetScalar(prhs[3]);
-  if(  !observer.in( *my_environment , epsilon )  )
-    observer = observer.projection_onto_boundary_of( *my_environment );
-  observer.snap_to_vertices_of( (*my_environment) , snap_distance);
-  observer.snap_to_boundary_of( (*my_environment) , snap_distance);
-  //observer.snap_to_vertices_of( (*my_environment) , snap_distance);
+  if (!observer.in(*my_environment, epsilon))
+    observer = observer.projection_onto_boundary_of(*my_environment);
+  observer.snap_to_vertices_of((*my_environment), snap_distance);
+  observer.snap_to_boundary_of((*my_environment), snap_distance);
+  // observer.snap_to_vertices_of( (*my_environment) , snap_distance);
 
+  // Compute Visibility_Polygon
+  VisiLibity::Visibility_Polygon my_vis_poly(observer, (*my_environment),
+                                             epsilon);
 
-  //Compute Visibility_Polygon
-  VisiLibity::Visibility_Polygon my_vis_poly( observer,
-					      (*my_environment),
-					      epsilon);
-
-  
-  //Create an mxArray for the output
-  plhs[0] = mxCreateDoubleMatrix( my_vis_poly.n(), 2, mxREAL );
-  //Create a pointer to output
+  // Create an mxArray for the output
+  plhs[0] = mxCreateDoubleMatrix(my_vis_poly.n(), 2, mxREAL);
+  // Create a pointer to output
   double *out = mxGetPr(plhs[0]);
-  //Populate the output
-  for (int i=0; i<my_vis_poly.n(); i++){
-    out[i]                   = my_vis_poly[i].x();
+  // Populate the output
+  for (int i = 0; i < my_vis_poly.n(); i++) {
+    out[i] = my_vis_poly[i].x();
     out[my_vis_poly.n() + i] = my_vis_poly[i].y();
   }
- 
 
   delete my_environment;
 

--- a/src/visilibity.cpp
+++ b/src/visilibity.cpp
@@ -23,3637 +23,3142 @@ You should have received a copy of the GNU Lesser General Public
 License along with VisiLibity.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-
-#include "visilibity.hpp"  //VisiLibity header
-#include <cmath>         //math functions in std namespace
+#include "visilibity.hpp" //VisiLibity header
+#include <cmath>          //math functions in std namespace
+#include <queue>          //queue and priority_queue
+#include <set>            //priority queues with iteration,
 #include <vector>
-#include <queue>         //queue and priority_queue
-#include <set>           //priority queues with iteration,
-                         //integrated keys
-#include <list>
-#include <algorithm>     //sorting, min, max, reverse
-#include <cstdlib>       //rand and srand
-#include <ctime>         //Unix time
-#include <fstream>       //file I/O
+// integrated keys
+#include <algorithm> //sorting, min, max, reverse
+#include <cassert>   //assertions
+#include <cstdlib>   //rand and srand
+#include <cstring>   //gives C-string manipulation
+#include <ctime>     //Unix time
+#include <fstream>   //file I/O
 #include <iostream>
-#include <cstring>       //gives C-string manipulation
-#include <string>        //string class
-#include <cassert>       //assertions
+#include <list>
+#include <string> //string class
 
-
-///Hide helping functions in unnamed namespace (local to .C file).
-namespace
-{
-  
-}
-
+/// Hide helping functions in unnamed namespace (local to .C file).
+namespace {}
 
 /// VisiLibity's sole namespace
-namespace VisiLibity
-{
+namespace VisiLibity {
 
-  double uniform_random_sample(double lower_bound, double upper_bound)
-  {
-    assert( lower_bound <= upper_bound );
-    if( lower_bound == upper_bound )
-      return lower_bound;
-    double sample_point;
-    double span = upper_bound - lower_bound;
-    sample_point = lower_bound 
-                   + span * static_cast<double>( std::rand() )
-                   / static_cast<double>( RAND_MAX );
-    return sample_point;
-  }
+double uniform_random_sample(double lower_bound, double upper_bound) {
+  assert(lower_bound <= upper_bound);
+  if (lower_bound == upper_bound)
+    return lower_bound;
+  double sample_point;
+  double span = upper_bound - lower_bound;
+  sample_point = lower_bound + span * static_cast<double>(std::rand()) /
+                                   static_cast<double>(RAND_MAX);
+  return sample_point;
+}
 
+// Point
 
-  //Point
+Point Point::projection_onto(const Line_Segment &line_segment_temp) const {
+  assert(*this == *this and line_segment_temp.size() > 0);
 
+  if (line_segment_temp.size() == 1)
+    return line_segment_temp.first();
+  // The projection of point_temp onto the line determined by
+  // line_segment_temp can be represented as an affine combination
+  // expressed in the form projection of Point =
+  // theta*line_segment_temp.first +
+  //(1.0-theta)*line_segment_temp.second.  if theta is outside
+  // the interval [0,1], then one of the Line_Segment's endpoints
+  // must be closest to calling Point.
+  double theta =
+      ((line_segment_temp.second().x() - x()) *
+           (line_segment_temp.second().x() - line_segment_temp.first().x()) +
+       (line_segment_temp.second().y() - y()) *
+           (line_segment_temp.second().y() - line_segment_temp.first().y())) /
+      (pow(line_segment_temp.second().x() - line_segment_temp.first().x(), 2) +
+       pow(line_segment_temp.second().y() - line_segment_temp.first().y(), 2));
+  // std::cout << "\E[1;37;40m" << "Theta is: " << theta << "\x1b[0m"
+  //<< std::endl;
+  if ((0.0 <= theta) and (theta <= 1.0))
+    return theta * line_segment_temp.first() +
+           (1.0 - theta) * line_segment_temp.second();
+  // Else pick closest endpoint.
+  if (distance(*this, line_segment_temp.first()) <
+      distance(*this, line_segment_temp.second()))
+    return line_segment_temp.first();
+  return line_segment_temp.second();
+}
 
-  Point Point::projection_onto(const Line_Segment& line_segment_temp) const
-  {
-    assert( *this == *this
-	    and line_segment_temp.size() > 0 );
+Point Point::projection_onto(const Ray &ray_temp) const {
+  assert(*this == *this and ray_temp == ray_temp);
 
-    if(line_segment_temp.size() == 1)
-      return line_segment_temp.first();
-    //The projection of point_temp onto the line determined by
-    //line_segment_temp can be represented as an affine combination
-    //expressed in the form projection of Point =
-    //theta*line_segment_temp.first +
-    //(1.0-theta)*line_segment_temp.second.  if theta is outside
-    //the interval [0,1], then one of the Line_Segment's endpoints
-    //must be closest to calling Point.
-    double theta = 
-      ( (line_segment_temp.second().x()-x())
-	*(line_segment_temp.second().x()
-	  -line_segment_temp.first().x()) 
-	+ (line_segment_temp.second().y()-y())
-	*(line_segment_temp.second().y()
-	  -line_segment_temp.first().y()) ) 
-      / ( pow(line_segment_temp.second().x()
-	      -line_segment_temp.first().x(),2)
-	  + pow(line_segment_temp.second().y()
-		-line_segment_temp.first().y(),2) );
-    //std::cout << "\E[1;37;40m" << "Theta is: " << theta << "\x1b[0m"
-    //<< std::endl;
-    if( (0.0<=theta) and (theta<=1.0) )
-      return theta*line_segment_temp.first() 
-	+ (1.0-theta)*line_segment_temp.second();
-    //Else pick closest endpoint.
-    if( distance(*this, line_segment_temp.first()) 
-	< distance(*this, line_segment_temp.second()) )
-      return line_segment_temp.first();
-    return line_segment_temp.second();
-  }
+  // Construct a Line_Segment parallel with the Ray which is so long,
+  // that the projection of the the calling Point onto that
+  // Line_Segment must be the same as the projection of the calling
+  // Point onto the Ray.
+  double R = distance(*this, ray_temp.base_point());
+  Line_Segment seg_approx = Line_Segment(
+      ray_temp.base_point(),
+      ray_temp.base_point() + Point(R * std::cos(ray_temp.bearing().get()),
+                                    R * std::sin(ray_temp.bearing().get())));
+  return projection_onto(seg_approx);
+}
 
+Point Point::projection_onto(const Polyline &polyline_temp) const {
+  assert(*this == *this and polyline_temp.size() > 0);
 
-  Point Point::projection_onto(const Ray& ray_temp) const
-  {
-    assert( *this == *this
-	    and ray_temp == ray_temp );
-
-    //Construct a Line_Segment parallel with the Ray which is so long,
-    //that the projection of the the calling Point onto that
-    //Line_Segment must be the same as the projection of the calling
-    //Point onto the Ray.
-    double R = distance( *this , ray_temp.base_point() );
-    Line_Segment seg_approx =
-      Line_Segment(  ray_temp.base_point(), ray_temp.base_point() +
-		     Point( R*std::cos(ray_temp.bearing().get()),
-			    R*std::sin(ray_temp.bearing().get()) )  );
-    return projection_onto( seg_approx );
-  }
-
-
- Point Point::projection_onto(const Polyline& polyline_temp) const
-  {
-    assert( *this == *this
-	    and polyline_temp.size() > 0 );
-
-    Point running_projection = polyline_temp[0];
-    double running_min = distance(*this, running_projection);    
-    Point point_temp;
-    for(unsigned i=0; i<=polyline_temp.size()-1; i++){
-      point_temp = projection_onto( Line_Segment(polyline_temp[i],
-						 polyline_temp[i+1]) );
-      if( distance(*this, point_temp) < running_min ){
-	running_projection = point_temp;
-	running_min = distance(*this, running_projection);
-      }
+  Point running_projection = polyline_temp[0];
+  double running_min = distance(*this, running_projection);
+  Point point_temp;
+  for (unsigned i = 0; i <= polyline_temp.size() - 1; i++) {
+    point_temp =
+        projection_onto(Line_Segment(polyline_temp[i], polyline_temp[i + 1]));
+    if (distance(*this, point_temp) < running_min) {
+      running_projection = point_temp;
+      running_min = distance(*this, running_projection);
     }
-    return running_projection;
   }
+  return running_projection;
+}
 
+Point Point::projection_onto_vertices_of(const Polygon &polygon_temp) const {
+  assert(*this == *this and polygon_temp.vertices_.size() > 0);
 
-  Point Point::projection_onto_vertices_of(const Polygon& polygon_temp) const
-  {
-    assert(*this == *this 
-	   and polygon_temp.vertices_.size() > 0 );
-
-    Point running_projection = polygon_temp[0];
-    double running_min = distance(*this, running_projection);
-    for(unsigned i=1; i<=polygon_temp.n()-1; i++){
-      if( distance(*this, polygon_temp[i]) < running_min ){
-	running_projection = polygon_temp[i];
-	running_min = distance(*this, running_projection);
-      }
+  Point running_projection = polygon_temp[0];
+  double running_min = distance(*this, running_projection);
+  for (unsigned i = 1; i <= polygon_temp.n() - 1; i++) {
+    if (distance(*this, polygon_temp[i]) < running_min) {
+      running_projection = polygon_temp[i];
+      running_min = distance(*this, running_projection);
     }
-    return running_projection;
   }
+  return running_projection;
+}
 
+Point Point::projection_onto_vertices_of(
+    const Environment &environment_temp) const {
+  assert(*this == *this and environment_temp.n() > 0);
 
-  Point Point::projection_onto_vertices_of(const Environment&
-					   environment_temp) const
-  {
-    assert(*this == *this 
-	   and environment_temp.n() > 0 );
-
-    Point running_projection 
-      = projection_onto_vertices_of(environment_temp.outer_boundary_);
-    double running_min = distance(*this, running_projection);   
-    Point point_temp;
-    for(unsigned i=0; i<environment_temp.h(); i++){
-      point_temp = projection_onto_vertices_of(environment_temp.holes_[i]);
-      if( distance(*this, point_temp) < running_min ){
-	running_projection = point_temp;
-	running_min = distance(*this, running_projection);
-      }
+  Point running_projection =
+      projection_onto_vertices_of(environment_temp.outer_boundary_);
+  double running_min = distance(*this, running_projection);
+  Point point_temp;
+  for (unsigned i = 0; i < environment_temp.h(); i++) {
+    point_temp = projection_onto_vertices_of(environment_temp.holes_[i]);
+    if (distance(*this, point_temp) < running_min) {
+      running_projection = point_temp;
+      running_min = distance(*this, running_projection);
     }
-    return running_projection;
   }
+  return running_projection;
+}
 
+Point Point::projection_onto_boundary_of(const Polygon &polygon_temp) const {
+  assert(*this == *this and polygon_temp.n() > 0);
 
-  Point Point::projection_onto_boundary_of(const Polygon& polygon_temp) const
-  {
-    assert( *this == *this
-	    and polygon_temp.n() > 0 );
-
-    Point running_projection = polygon_temp[0];
-    double running_min = distance(*this, running_projection);    
-    Point point_temp;
-    for(unsigned i=0; i<=polygon_temp.n()-1; i++){
-      point_temp = projection_onto( Line_Segment(polygon_temp[i],
-						 polygon_temp[i+1]) );
-      if( distance(*this, point_temp) < running_min ){
-	running_projection = point_temp;
-	running_min = distance(*this, running_projection);
-      }
+  Point running_projection = polygon_temp[0];
+  double running_min = distance(*this, running_projection);
+  Point point_temp;
+  for (unsigned i = 0; i <= polygon_temp.n() - 1; i++) {
+    point_temp =
+        projection_onto(Line_Segment(polygon_temp[i], polygon_temp[i + 1]));
+    if (distance(*this, point_temp) < running_min) {
+      running_projection = point_temp;
+      running_min = distance(*this, running_projection);
     }
-    return running_projection;
   }
+  return running_projection;
+}
 
+Point Point::projection_onto_boundary_of(
+    const Environment &environment_temp) const {
+  assert(*this == *this and environment_temp.n() > 0);
 
-  Point Point::projection_onto_boundary_of(const Environment&
-					   environment_temp) const
-  {
-    assert( *this == *this
-	    and environment_temp.n() > 0 );
-
-    Point running_projection 
-      = projection_onto_boundary_of(environment_temp.outer_boundary_);
-    double running_min = distance(*this, running_projection);
-    Point point_temp;
-    for(unsigned i=0; i<environment_temp.h(); i++){
-      point_temp = projection_onto_boundary_of(environment_temp.holes_[i]);
-      if( distance(*this, point_temp) < running_min ){
-	running_projection = point_temp;
-	running_min = distance(*this, running_projection);
-      }
+  Point running_projection =
+      projection_onto_boundary_of(environment_temp.outer_boundary_);
+  double running_min = distance(*this, running_projection);
+  Point point_temp;
+  for (unsigned i = 0; i < environment_temp.h(); i++) {
+    point_temp = projection_onto_boundary_of(environment_temp.holes_[i]);
+    if (distance(*this, point_temp) < running_min) {
+      running_projection = point_temp;
+      running_min = distance(*this, running_projection);
     }
-    return running_projection;
   }
+  return running_projection;
+}
 
-  
-  bool Point::on_boundary_of(const Polygon& polygon_temp,
-			     double epsilon) const
-  {
-    assert( *this == *this
-	    and polygon_temp.vertices_.size() > 0 );
+bool Point::on_boundary_of(const Polygon &polygon_temp, double epsilon) const {
+  assert(*this == *this and polygon_temp.vertices_.size() > 0);
 
-    if( distance(*this, projection_onto_boundary_of(polygon_temp) ) 
-	<= epsilon ){
-      return true;
-    }
-    return false;
-  }
- 
-
-  bool Point::on_boundary_of(const Environment& environment_temp,
-			     double epsilon) const
-  {
-    assert( *this == *this
-	    and environment_temp.outer_boundary_.n() > 0 );
-
-    if( distance(*this, projection_onto_boundary_of(environment_temp) ) 
-	<= epsilon ){
-      return true;
-    }
-    return false;
-  }    
-
-
-  bool Point::in(const Line_Segment& line_segment_temp,
-		 double epsilon) const
-  {
-    assert( *this == *this
-	    and line_segment_temp.size() > 0 );
-
-    if( distance(*this, line_segment_temp) < epsilon )
-      return true;
-    return false;
-  }
-
-
-  bool Point::in_relative_interior_of(const Line_Segment& line_segment_temp,
-				      double epsilon) const
-  {
-    assert( *this == *this
-	    and line_segment_temp.size() > 0 );
-      
-    return in(line_segment_temp, epsilon) 
-      and distance(*this, line_segment_temp.first()) > epsilon
-      and distance(*this, line_segment_temp.second()) > epsilon;
-  }
-
-
-  bool Point::in(const Polygon& polygon_temp,
-		 double epsilon) const
-  {
-    assert( *this == *this
-	    and polygon_temp.vertices_.size() > 0 );
-
-    int n = polygon_temp.vertices_.size();
-    if( on_boundary_of(polygon_temp, epsilon) )
-      return true;
-    // Then check the number of times a ray emanating from the Point
-    // crosses the boundary of the Polygon.  An odd number of
-    // crossings indicates the Point is in the interior of the
-    // Polygon.  Based on
-    // http://www.ecse.rpi.edu/Homepages/wrf/Research/Short_Notes/pnpoly.html
-    int i, j; bool c = false;
-    for (i = 0, j = n-1; i < n; j = i++){
-      if ( (((polygon_temp[i].y() <= y()) 
-	     and (y() < polygon_temp[j].y())) 
-	    or ((polygon_temp[j].y() <= y()) 
-		and (y() < polygon_temp[i].y()))) 
-	   and ( x() < (polygon_temp[j].x() 
-		       - polygon_temp[i].x()) 
-		* (y() - polygon_temp[i].y()) 
-		/ (polygon_temp[j].y() 
-		   - polygon_temp[i].y()) 
-		   + polygon_temp[i].x()) )     
-	c = !c;
-    }
-    return c;
-  }
- 
-
-  bool Point::in(const Environment& environment_temp, double epsilon) const
-  {
-    assert( *this == *this
-	    and environment_temp.outer_boundary_.n() > 0 );
-
-    //On outer boundary?
-    if( on_boundary_of(environment_temp, epsilon) )
-      return true;
-    //Not in outer boundary?
-    if( !in(environment_temp.outer_boundary_, epsilon) )
-      return false;
-    //In hole?
-    for(unsigned i=0; i<environment_temp.h(); i++)
-      if( in(environment_temp.holes_[i]) )
-	return false;
-    //Must be in interior.
+  if (distance(*this, projection_onto_boundary_of(polygon_temp)) <= epsilon) {
     return true;
   }
+  return false;
+}
 
+bool Point::on_boundary_of(const Environment &environment_temp,
+                           double epsilon) const {
+  assert(*this == *this and environment_temp.outer_boundary_.n() > 0);
 
-  bool Point::is_endpoint_of(const Line_Segment& line_segment_temp,
-			     double epsilon) const
-  {
-    assert( *this == *this
-	    and line_segment_temp.size() > 0 );
+  if (distance(*this, projection_onto_boundary_of(environment_temp)) <=
+      epsilon) {
+    return true;
+  }
+  return false;
+}
 
-    if( distance(line_segment_temp.first(), *this)<=epsilon 
-	or distance(line_segment_temp.second(), *this)<=epsilon )
-      return true;
+bool Point::in(const Line_Segment &line_segment_temp, double epsilon) const {
+  assert(*this == *this and line_segment_temp.size() > 0);
+
+  if (distance(*this, line_segment_temp) < epsilon)
+    return true;
+  return false;
+}
+
+bool Point::in_relative_interior_of(const Line_Segment &line_segment_temp,
+                                    double epsilon) const {
+  assert(*this == *this and line_segment_temp.size() > 0);
+
+  return in(line_segment_temp, epsilon) and
+         distance(*this, line_segment_temp.first()) > epsilon and
+         distance(*this, line_segment_temp.second()) > epsilon;
+}
+
+bool Point::in(const Polygon &polygon_temp, double epsilon) const {
+  assert(*this == *this and polygon_temp.vertices_.size() > 0);
+
+  int n = polygon_temp.vertices_.size();
+  if (on_boundary_of(polygon_temp, epsilon))
+    return true;
+  // Then check the number of times a ray emanating from the Point
+  // crosses the boundary of the Polygon.  An odd number of
+  // crossings indicates the Point is in the interior of the
+  // Polygon.  Based on
+  // http://www.ecse.rpi.edu/Homepages/wrf/Research/Short_Notes/pnpoly.html
+  int i, j;
+  bool c = false;
+  for (i = 0, j = n - 1; i < n; j = i++) {
+    if ((((polygon_temp[i].y() <= y()) and (y() < polygon_temp[j].y())) or
+         ((polygon_temp[j].y() <= y()) and (y() < polygon_temp[i].y()))) and
+        (x() < (polygon_temp[j].x() - polygon_temp[i].x()) *
+                       (y() - polygon_temp[i].y()) /
+                       (polygon_temp[j].y() - polygon_temp[i].y()) +
+                   polygon_temp[i].x()))
+      c = !c;
+  }
+  return c;
+}
+
+bool Point::in(const Environment &environment_temp, double epsilon) const {
+  assert(*this == *this and environment_temp.outer_boundary_.n() > 0);
+
+  // On outer boundary?
+  if (on_boundary_of(environment_temp, epsilon))
+    return true;
+  // Not in outer boundary?
+  if (!in(environment_temp.outer_boundary_, epsilon))
     return false;
-  }
-
-
-  void Point::snap_to_vertices_of(const Polygon& polygon_temp,
-				  double epsilon)
-  {
-    assert( *this == *this
-	    and polygon_temp.n() > 0 );
-
-    Point point_temp( this->projection_onto_vertices_of(polygon_temp) );
-    if(  distance( *this , point_temp ) <= epsilon )
-      *this = point_temp;
-  }
-  void Point::snap_to_vertices_of(const Environment& environment_temp,
-				  double epsilon)
-  {
-    assert( *this == *this
-	    and environment_temp.n() > 0 );
-
-    Point point_temp( this->projection_onto_vertices_of(environment_temp) );
-    if(  distance( *this , point_temp ) <= epsilon )
-      *this = point_temp;
-  }
-
-
-  void Point::snap_to_boundary_of(const Polygon& polygon_temp,
-				  double epsilon)
-  {
-    assert( *this == *this
-	    and polygon_temp.n() > 0 );
-
-    Point point_temp( this->projection_onto_boundary_of(polygon_temp) );
-    if(  distance( *this , point_temp ) <= epsilon )
-      *this = point_temp;
-  }
-  void Point::snap_to_boundary_of(const Environment& environment_temp,
-				  double epsilon)
-  {
-    assert( *this == *this
-	    and environment_temp.n() > 0 );
-
-    Point point_temp( this->projection_onto_boundary_of(environment_temp) );
-    if(  distance( *this , point_temp ) <= epsilon )
-      *this = point_temp;
-  }
-
-
-  bool operator == (const Point& point1, const Point& point2)
-  { return (  ( point1.x() == point2.x() ) 
-	      and ( point1.y() == point2.y() )  ); }
-  bool operator != (const Point& point1, const Point& point2)
-  { return !( point1 == point2 ); }
-
-
-  bool operator < (const Point& point1, const Point& point2)
-  {
-    if( point1 != point1 or point2 != point2 )
+  // In hole?
+  for (unsigned i = 0; i < environment_temp.h(); i++)
+    if (in(environment_temp.holes_[i]))
       return false;
-    if(point1.x() < point2.x())
-      return true;
-    else if(  ( point1.x() == point2.x() ) 
-	      and ( point1.y() < point2.y() )  )
-      return true;
+  // Must be in interior.
+  return true;
+}
+
+bool Point::is_endpoint_of(const Line_Segment &line_segment_temp,
+                           double epsilon) const {
+  assert(*this == *this and line_segment_temp.size() > 0);
+
+  if (distance(line_segment_temp.first(), *this) <= epsilon or
+      distance(line_segment_temp.second(), *this) <= epsilon)
+    return true;
+  return false;
+}
+
+void Point::snap_to_vertices_of(const Polygon &polygon_temp, double epsilon) {
+  assert(*this == *this and polygon_temp.n() > 0);
+
+  Point point_temp(this->projection_onto_vertices_of(polygon_temp));
+  if (distance(*this, point_temp) <= epsilon)
+    *this = point_temp;
+}
+void Point::snap_to_vertices_of(const Environment &environment_temp,
+                                double epsilon) {
+  assert(*this == *this and environment_temp.n() > 0);
+
+  Point point_temp(this->projection_onto_vertices_of(environment_temp));
+  if (distance(*this, point_temp) <= epsilon)
+    *this = point_temp;
+}
+
+void Point::snap_to_boundary_of(const Polygon &polygon_temp, double epsilon) {
+  assert(*this == *this and polygon_temp.n() > 0);
+
+  Point point_temp(this->projection_onto_boundary_of(polygon_temp));
+  if (distance(*this, point_temp) <= epsilon)
+    *this = point_temp;
+}
+void Point::snap_to_boundary_of(const Environment &environment_temp,
+                                double epsilon) {
+  assert(*this == *this and environment_temp.n() > 0);
+
+  Point point_temp(this->projection_onto_boundary_of(environment_temp));
+  if (distance(*this, point_temp) <= epsilon)
+    *this = point_temp;
+}
+
+bool operator==(const Point &point1, const Point &point2) {
+  return ((point1.x() == point2.x()) and (point1.y() == point2.y()));
+}
+bool operator!=(const Point &point1, const Point &point2) {
+  return !(point1 == point2);
+}
+
+bool operator<(const Point &point1, const Point &point2) {
+  if (point1 != point1 or point2 != point2)
     return false;
-  }
-  bool operator > (const Point& point1, const Point& point2)
-  {
-    if( point1 != point1 or point2 != point2 )
-      return false;
-    if( point1.x() > point2.x() )
-      return true;
-    else if(  ( point1.x() == point2.x() ) 
-	      and ( point1.y() > point2.y() )  )
-      return true;
+  if (point1.x() < point2.x())
+    return true;
+  else if ((point1.x() == point2.x()) and (point1.y() < point2.y()))
+    return true;
+  return false;
+}
+bool operator>(const Point &point1, const Point &point2) {
+  if (point1 != point1 or point2 != point2)
     return false;
+  if (point1.x() > point2.x())
+    return true;
+  else if ((point1.x() == point2.x()) and (point1.y() > point2.y()))
+    return true;
+  return false;
+}
+bool operator>=(const Point &point1, const Point &point2) {
+  if (point1 != point1 or point2 != point2)
+    return false;
+  return !(point1 < point2);
+}
+bool operator<=(const Point &point1, const Point &point2) {
+  if (point1 != point1 or point2 != point2)
+    return false;
+  return !(point1 > point2);
+}
+
+Point operator+(const Point &point1, const Point &point2) {
+  return Point(point1.x() + point2.x(), point1.y() + point2.y());
+}
+Point operator-(const Point &point1, const Point &point2) {
+  return Point(point1.x() - point2.x(), point1.y() - point2.y());
+}
+
+Point operator*(const Point &point1, const Point &point2) {
+  return Point(point1.x() * point2.x(), point1.y() * point2.y());
+}
+
+Point operator*(double scalar, const Point &point2) {
+  return Point(scalar * point2.x(), scalar * point2.y());
+}
+Point operator*(const Point &point1, double scalar) {
+  return Point(scalar * point1.x(), scalar * point1.y());
+}
+
+double cross(const Point &point1, const Point &point2) {
+  assert(point1 == point1 and point2 == point2);
+
+  // The area of the parallelogram created by the Points viewed as vectors.
+  return point1.x() * point2.y() - point2.x() * point1.y();
+}
+
+double distance(const Point &point1, const Point &point2) {
+  assert(point1 == point1 and point2 == point2);
+
+  return sqrt(pow(point1.x() - point2.x(), 2) +
+              pow(point1.y() - point2.y(), 2));
+}
+
+double distance(const Point &point_temp,
+                const Line_Segment &line_segment_temp) {
+  assert(point_temp == point_temp and line_segment_temp.size() > 0);
+
+  return distance(point_temp, point_temp.projection_onto(line_segment_temp));
+}
+double distance(const Line_Segment &line_segment_temp,
+                const Point &point_temp) {
+  return distance(point_temp, line_segment_temp);
+}
+
+double distance(const Point &point_temp, const Ray &ray_temp) {
+  assert(point_temp == point_temp and ray_temp == ray_temp);
+  return distance(point_temp, point_temp.projection_onto(ray_temp));
+}
+double distance(const Ray &ray_temp, const Point &point_temp) {
+  return distance(point_temp, point_temp.projection_onto(ray_temp));
+}
+
+double distance(const Point &point_temp, const Polyline &polyline_temp) {
+  assert(point_temp == point_temp and polyline_temp.size() > 0);
+
+  double running_min = distance(point_temp, polyline_temp[0]);
+  double distance_temp;
+  for (unsigned i = 0; i < polyline_temp.size() - 1; i++) {
+    distance_temp = distance(
+        point_temp, Line_Segment(polyline_temp[i], polyline_temp[i + 1]));
+    if (distance_temp < running_min)
+      running_min = distance_temp;
   }
-  bool operator >= (const Point& point1, const Point& point2)
-  {
-    if( point1 != point1 or point2 != point2 )
-      return false;
-    return !( point1 < point2 );
+  return running_min;
+}
+double distance(const Polyline &polyline_temp, const Point &point_temp) {
+  return distance(point_temp, polyline_temp);
+}
+
+double boundary_distance(const Point &point_temp, const Polygon &polygon_temp) {
+  assert(point_temp == point_temp and polygon_temp.n() > 0);
+
+  double running_min = distance(point_temp, polygon_temp[0]);
+  double distance_temp;
+  for (unsigned i = 0; i <= polygon_temp.n(); i++) {
+    distance_temp = distance(
+        point_temp, Line_Segment(polygon_temp[i], polygon_temp[i + 1]));
+    if (distance_temp < running_min)
+      running_min = distance_temp;
   }
-  bool operator <= (const Point& point1, const Point& point2)
-  {
-    if( point1 != point1 or point2 != point2 )
-      return false;
-    return !( point1 > point2 );
+  return running_min;
+}
+double boundary_distance(const Polygon &polygon_temp, const Point &point_temp) {
+  return boundary_distance(point_temp, polygon_temp);
+}
+
+double boundary_distance(const Point &point_temp,
+                         const Environment &environment_temp) {
+  assert(point_temp == point_temp and environment_temp.n() > 0);
+
+  double running_min = distance(point_temp, environment_temp[0][0]);
+  double distance_temp;
+  for (unsigned i = 0; i <= environment_temp.h(); i++) {
+    distance_temp = boundary_distance(point_temp, environment_temp[i]);
+    if (distance_temp < running_min)
+      running_min = distance_temp;
   }
+  return running_min;
+}
+double boundary_distance(const Environment &environment_temp,
+                         const Point &point_temp) {
+  return boundary_distance(point_temp, environment_temp);
+}
 
+std::ostream &operator<<(std::ostream &outs, const Point &point_temp) {
+  outs << point_temp.x() << "  " << point_temp.y();
+  return outs;
+}
 
-  Point operator + (const Point& point1, const Point& point2)
-  {
-    return Point( point1.x() + point2.x(),
-		  point1.y() + point2.y() );
-  }
-  Point operator - (const Point& point1, const Point& point2)
-  {
-    return Point( point1.x() - point2.x(),
-		  point1.y() - point2.y() );
-  }
+// Line_Segment
 
+Line_Segment::Line_Segment() {
+  endpoints_ = NULL;
+  size_ = 0;
+}
 
-  Point operator * (const Point& point1, const Point& point2)
-  {
-    return Point( point1.x()*point2.x(),
-		  point1.y()*point2.y() ); 
-  }
-
-
-  Point operator * (double scalar, const Point& point2)
-  {
-    return Point( scalar*point2.x(),
-		  scalar*point2.y()); 
-  }
-  Point operator * (const Point& point1, double scalar)
-  {
-    return Point( scalar*point1.x(),
-		  scalar*point1.y()); 
-  }
-
-
-  double cross(const Point& point1, const Point& point2)
-  {
-    assert( point1 == point1
-	    and point2 == point2 );
-
-    //The area of the parallelogram created by the Points viewed as vectors.
-    return point1.x()*point2.y() - point2.x()*point1.y();
-  }
-
-
-  double distance(const Point& point1, const Point& point2)
-  {
-    assert( point1 == point1
-	    and point2 == point2 );
-
-    return sqrt(  pow( point1.x() - point2.x() , 2 )
-		  + pow( point1.y() - point2.y() , 2 )  );
-  }
-
-
-  double distance(const Point& point_temp,
-		  const Line_Segment& line_segment_temp)
-  {
-    assert( point_temp == point_temp
-	    and line_segment_temp.size() > 0 );
-
-    return distance( point_temp, 
-		     point_temp.projection_onto(line_segment_temp) );
-  }
-  double distance(const Line_Segment& line_segment_temp,
-		  const Point& point_temp)
-  {
-    return distance( point_temp,
-		     line_segment_temp );
-  }
-
-
-  double distance(const Point& point_temp,
-		  const Ray& ray_temp)
-  {
-    assert( point_temp == point_temp
-	    and ray_temp == ray_temp );
-    return distance( point_temp, 
-		     point_temp.projection_onto(ray_temp) );
-  }
-  double distance(const Ray& ray_temp,
-		  const Point& point_temp)
-  {
-    return distance( point_temp,
-		     point_temp.projection_onto(ray_temp) );
-  }
-
-
-  double distance(const Point& point_temp,
-		  const Polyline& polyline_temp)
-  {
-    assert( point_temp == point_temp
-	    and polyline_temp.size() > 0 );
-
-    double running_min = distance(point_temp, polyline_temp[0]);
-    double distance_temp;
-    for(unsigned i=0; i<polyline_temp.size()-1; i++){
-      distance_temp = distance(point_temp, Line_Segment(polyline_temp[i],
-							polyline_temp[i+1]) );
-      if(distance_temp < running_min)
-	running_min = distance_temp;
-    }
-    return running_min;
-  }
-  double distance(const Polyline& polyline_temp,
-		  const Point& point_temp)
-  {
-    return distance(point_temp, polyline_temp);
-  }
-
-
-  double boundary_distance(const Point& point_temp,
-			   const Polygon& polygon_temp)
-  {
-    assert( point_temp == point_temp
-	    and polygon_temp.n() > 0);
-
-    double running_min = distance(point_temp, polygon_temp[0]);
-    double distance_temp;
-    for(unsigned i=0; i<=polygon_temp.n(); i++){
-      distance_temp = distance(point_temp, Line_Segment(polygon_temp[i],
-							polygon_temp[i+1]) );
-      if(distance_temp < running_min)
-	running_min = distance_temp;
-    }
-    return running_min;
-  }
-  double boundary_distance(const Polygon& polygon_temp, const Point& point_temp)
-  {
-    return boundary_distance(point_temp, polygon_temp);
-  } 
-
- 
-  double boundary_distance(const Point& point_temp,
-			   const Environment& environment_temp)
-  {
-    assert( point_temp == point_temp
-	    and environment_temp.n() > 0 );
-
-    double running_min = distance(point_temp, environment_temp[0][0]);
-    double distance_temp;
-    for(unsigned i=0; i <= environment_temp.h(); i++){
-      distance_temp = boundary_distance(point_temp, environment_temp[i]);
-      if(distance_temp < running_min)
-	running_min = distance_temp;
-    }
-    return running_min;
-  }  
-  double boundary_distance(const Environment& environment_temp,
-			   const Point& point_temp)
-  {
-    return boundary_distance(point_temp, environment_temp);
-  }
-
-
-  std::ostream& operator << (std::ostream& outs, const Point& point_temp)
-  {
-    outs << point_temp.x() << "  " << point_temp.y();
-    return outs;
-  }
-
-
-  //Line_Segment
-
-
-  Line_Segment::Line_Segment()
-  {
+Line_Segment::Line_Segment(const Line_Segment &line_segment_temp) {
+  switch (line_segment_temp.size_) {
+  case 0:
     endpoints_ = NULL;
     size_ = 0;
+    break;
+  case 1:
+    endpoints_ = new Point[1];
+    endpoints_[0] = line_segment_temp.endpoints_[0];
+    size_ = 1;
+    break;
+  case 2:
+    endpoints_ = new Point[2];
+    endpoints_[0] = line_segment_temp.endpoints_[0];
+    endpoints_[1] = line_segment_temp.endpoints_[1];
+    size_ = 2;
   }
+}
 
+Line_Segment::Line_Segment(const Point &point_temp) {
+  endpoints_ = new Point[1];
+  endpoints_[0] = point_temp;
+  size_ = 1;
+}
 
-  Line_Segment::Line_Segment(const Line_Segment& line_segment_temp)
-  {
-    switch(line_segment_temp.size_){
-    case 0:
-      endpoints_ = NULL;
-      size_ = 0;
-      break;
-    case 1:
-      endpoints_ = new Point[1];
-      endpoints_[0] = line_segment_temp.endpoints_[0];
-      size_ = 1;
-      break;
-    case 2:
-      endpoints_ = new Point[2];
-      endpoints_[0] = line_segment_temp.endpoints_[0];
-      endpoints_[1] = line_segment_temp.endpoints_[1];
-      size_ = 2;
+Line_Segment::Line_Segment(const Point &first_point_temp,
+                           const Point &second_point_temp, double epsilon) {
+  if (distance(first_point_temp, second_point_temp) <= epsilon) {
+    endpoints_ = new Point[1];
+    endpoints_[0] = first_point_temp;
+    size_ = 1;
+  } else {
+    endpoints_ = new Point[2];
+    endpoints_[0] = first_point_temp;
+    endpoints_[1] = second_point_temp;
+    size_ = 2;
+  }
+}
+
+Point Line_Segment::first() const {
+  assert(size() > 0);
+
+  return endpoints_[0];
+}
+
+Point Line_Segment::second() const {
+  assert(size() > 0);
+
+  if (size_ == 2)
+    return endpoints_[1];
+  else
+    return endpoints_[0];
+}
+
+Point Line_Segment::midpoint() const {
+  assert(size_ > 0);
+
+  return 0.5 * (first() + second());
+}
+
+double Line_Segment::length() const {
+  assert(size_ > 0);
+
+  return distance(first(), second());
+}
+
+bool Line_Segment::is_in_standard_form() const {
+  assert(size_ > 0);
+
+  if (size_ < 2)
+    return true;
+  return first() <= second();
+}
+
+Line_Segment &Line_Segment::operator=(const Line_Segment &line_segment_temp) {
+  // Makes sure not to delete dynamic vars before they're copied.
+  if (this == &line_segment_temp)
+    return *this;
+  delete[] endpoints_;
+  switch (line_segment_temp.size_) {
+  case 0:
+    endpoints_ = NULL;
+    size_ = 0;
+    break;
+  case 1:
+    endpoints_ = new Point[1];
+    endpoints_[0] = line_segment_temp.endpoints_[0];
+    size_ = 1;
+    break;
+  case 2:
+    endpoints_ = new Point[2];
+    endpoints_[0] = line_segment_temp.endpoints_[0];
+    endpoints_[1] = line_segment_temp.endpoints_[1];
+    size_ = 2;
+  }
+  return *this;
+}
+
+void Line_Segment::set_first(const Point &point_temp, double epsilon) {
+  Point second_point_temp;
+  switch (size_) {
+  case 0:
+    endpoints_ = new Point[1];
+    endpoints_[0] = point_temp;
+    size_ = 1;
+    break;
+  case 1:
+    if (distance(endpoints_[0], point_temp) <= epsilon) {
+      endpoints_[0] = point_temp;
+      return;
     }
-  }
-
-
-  Line_Segment::Line_Segment(const Point& point_temp)
-  {
+    second_point_temp = endpoints_[0];
+    delete[] endpoints_;
+    endpoints_ = new Point[2];
+    endpoints_[0] = point_temp;
+    endpoints_[1] = second_point_temp;
+    size_ = 2;
+    break;
+  case 2:
+    if (distance(point_temp, endpoints_[1]) > epsilon) {
+      endpoints_[0] = point_temp;
+      return;
+    }
+    delete[] endpoints_;
     endpoints_ = new Point[1];
     endpoints_[0] = point_temp;
     size_ = 1;
   }
+}
 
-
-  Line_Segment::Line_Segment(const Point& first_point_temp,
-			     const Point& second_point_temp, double epsilon)
-  {
-    if( distance(first_point_temp, second_point_temp) <= epsilon ){
-      endpoints_ = new Point[1];
-      endpoints_[0] = first_point_temp;
-      size_ = 1;
-    }
-    else{
-      endpoints_ = new Point[2];
-      endpoints_[0] = first_point_temp;
-      endpoints_[1] = second_point_temp;
-      size_ = 2;
-    }
-  }
-
-
-  Point Line_Segment::first() const
-  {
-    assert( size() > 0 );
-
-    return endpoints_[0];
-  }
-
-
-  Point Line_Segment::second() const
-  {
-    assert( size() > 0 );
-
-    if(size_==2)
-      return endpoints_[1];
-    else
-      return endpoints_[0];
-  }
-
-
-  Point Line_Segment::midpoint() const
-  {
-    assert( size_ > 0 );
-
-    return 0.5*( first() + second() );
-  }
-
-
-  double Line_Segment::length() const
-  {
-    assert( size_ > 0 );
-
-    return distance(first(), second());
-  }
-
-
-  bool Line_Segment::is_in_standard_form() const
-  {
-    assert( size_ > 0);
-
-    if(size_<2)
-      return true;
-    return first() <= second();
-  }
-
-
-  Line_Segment& Line_Segment::operator = (const Line_Segment& line_segment_temp)
-  {
-    //Makes sure not to delete dynamic vars before they're copied.
-    if(this==&line_segment_temp)
-      return *this;
-    delete [] endpoints_;
-    switch(line_segment_temp.size_){
-    case 0:
-      endpoints_ = NULL;
-      size_ = 0;
-      break;
-    case 1:
-      endpoints_ = new Point[1];
-      endpoints_[0] = line_segment_temp.endpoints_[0];
-      size_ = 1;
-      break;
-    case 2:
-      endpoints_ = new Point[2];
-      endpoints_[0] = line_segment_temp.endpoints_[0];
-      endpoints_[1] = line_segment_temp.endpoints_[1];
-      size_ = 2;
-    }
-    return *this;
-  }
-
-
-  void Line_Segment::set_first(const Point& point_temp, double epsilon)
-  {
-    Point second_point_temp;
-    switch(size_){
-    case 0:
-      endpoints_ = new Point[1];
+void Line_Segment::set_second(const Point &point_temp, double epsilon) {
+  Point first_point_temp;
+  switch (size_) {
+  case 0:
+    endpoints_ = new Point[1];
+    endpoints_[0] = point_temp;
+    size_ = 1;
+    break;
+  case 1:
+    if (distance(endpoints_[0], point_temp) <= epsilon) {
       endpoints_[0] = point_temp;
-      size_ = 1;
-      break;
-    case 1:
-      if( distance(endpoints_[0], point_temp) <= epsilon )
-	{ endpoints_[0] = point_temp; return; }
-      second_point_temp = endpoints_[0];
-      delete [] endpoints_;
-      endpoints_ = new Point[2];
-      endpoints_[0] = point_temp;
-      endpoints_[1] = second_point_temp;
-      size_ = 2;
-      break;
-    case 2:
-      if( distance(point_temp, endpoints_[1]) > epsilon )
-	{ endpoints_[0] = point_temp; return; }
-      delete [] endpoints_;
-      endpoints_ = new Point[1];
-      endpoints_[0] = point_temp;
-      size_ = 1;
-    }
-  }
-
-
-  void Line_Segment::set_second(const Point& point_temp, double epsilon)
-  {
-    Point first_point_temp;
-    switch(size_){
-    case 0:
-      endpoints_ = new Point[1];
-      endpoints_[0] = point_temp;
-      size_ = 1;
-      break;
-    case 1:
-      if( distance(endpoints_[0], point_temp) <= epsilon )
-	{ endpoints_[0] = point_temp; return; }
-      first_point_temp = endpoints_[0];
-      delete [] endpoints_;
-      endpoints_ = new Point[2];
-      endpoints_[0] = first_point_temp;
-      endpoints_[1] = point_temp;
-      size_ = 2;
-      break;
-    case 2:
-      if( distance(endpoints_[0], point_temp) > epsilon )
-	{ endpoints_[1] = point_temp; return; }
-      delete [] endpoints_;
-      endpoints_ = new Point[1];
-      endpoints_[0] = point_temp;
-      size_ = 1;
-    }
-  }
-
-
-  void Line_Segment::reverse()
-  {
-    if(size_<2)
       return;
-    Point point_temp(first());
-    endpoints_[0] = second();
+    }
+    first_point_temp = endpoints_[0];
+    delete[] endpoints_;
+    endpoints_ = new Point[2];
+    endpoints_[0] = first_point_temp;
     endpoints_[1] = point_temp;
+    size_ = 2;
+    break;
+  case 2:
+    if (distance(endpoints_[0], point_temp) > epsilon) {
+      endpoints_[1] = point_temp;
+      return;
+    }
+    delete[] endpoints_;
+    endpoints_ = new Point[1];
+    endpoints_[0] = point_temp;
+    size_ = 1;
   }
+}
 
+void Line_Segment::reverse() {
+  if (size_ < 2)
+    return;
+  Point point_temp(first());
+  endpoints_[0] = second();
+  endpoints_[1] = point_temp;
+}
 
-  void Line_Segment::enforce_standard_form()
-  {
-    if(first() > second())
-      reverse();
-  }
+void Line_Segment::enforce_standard_form() {
+  if (first() > second())
+    reverse();
+}
 
+void Line_Segment::clear() {
+  delete[] endpoints_;
+  endpoints_ = NULL;
+  size_ = 0;
+}
 
-  void Line_Segment::clear()
-  {
-    delete [] endpoints_;
-    endpoints_ = NULL;
-    size_ = 0;
-  }
+Line_Segment::~Line_Segment() { delete[] endpoints_; }
 
-
-  Line_Segment::~Line_Segment()
-  {
-    delete [] endpoints_;
-  }
-
-
-  bool  operator == (const Line_Segment& line_segment1,
-		     const Line_Segment& line_segment2)
-  {
-    if( line_segment1.size() != line_segment2.size() 
-	or line_segment1.size() == 0
-	or line_segment2.size() == 0 )
-      return false;
-    else if( line_segment1.first() == line_segment2.first()
-	     and line_segment1.second() == line_segment2.second() )
-      return true;
-    else
-      return false;
-  } 
-
-
-  bool  operator != (const Line_Segment& line_segment1,
-		     const Line_Segment& line_segment2)
-  {
-    return !( line_segment1 == line_segment2 );
-  } 
-
-
-  bool equivalent(Line_Segment line_segment1, 
-		  Line_Segment line_segment2, double epsilon)
-  {
-    if( line_segment1.size() != line_segment2.size()
-	or line_segment1.size() == 0
-	or line_segment2.size() == 0 )
-      return false;
-    else if(   (  distance( line_segment1.first(), 
-			    line_segment2.first() ) <= epsilon  
-		  and  distance( line_segment1.second(), 
-				 line_segment2.second() ) <= epsilon  )
-	    or (  distance( line_segment1.first(), 
-			    line_segment2.second() ) <= epsilon  
-		  and  distance( line_segment1.second(), 
-				 line_segment2.first() ) <= epsilon  )   )
-      return true;
-    else
-      return false;
-  }
-
-
-  double distance(const Line_Segment& line_segment1,
-		  const Line_Segment& line_segment2)
-  {
-    assert( line_segment1.size() > 0  and  line_segment2.size() > 0 );
-    
-    if(intersect_proper(line_segment1, line_segment2))
-      return 0;
-    //But if two line segments intersect improperly, the distance
-    //between them is equal to the minimum of the distances between
-    //all 4 endpoints_ and their respective projections onto the line
-    //segment they don't belong to.
-    double running_min, distance_temp;
-    running_min = distance(line_segment1.first(), line_segment2);
-    distance_temp = distance(line_segment1.second(), line_segment2);
-    if(distance_temp<running_min)
-      running_min = distance_temp;
-    distance_temp = distance(line_segment2.first(), line_segment1);
-    if(distance_temp<running_min)
-      running_min = distance_temp;
-    distance_temp = distance(line_segment2.second(), line_segment1);
-    if(distance_temp<running_min)
-      return distance_temp;
-    return running_min;
-  }
-
-
-  double boundary_distance(const Line_Segment& line_segment,
-			   const Polygon& polygon)
-  {
-    assert( line_segment.size() > 0 and polygon.n() > 0 );
-
-    double running_min = distance( line_segment , polygon[0] );
-    if( polygon.n() > 1 )
-      for(unsigned i=0; i<polygon.n(); i++){
-	double d = distance(  line_segment, 
-			      Line_Segment( polygon[i] , polygon[i+1] )  );
-	if( running_min > d )
-	  running_min = d;
-      }
-    return running_min;
-  }
-  double boundary_distance(const Polygon& polygon,
-			   const Line_Segment& line_segment)
-  { return boundary_distance( line_segment , polygon ); }
-
-
-  bool intersect(const Line_Segment& line_segment1,
-		 const Line_Segment& line_segment2, double epsilon)
-  {
-    if( line_segment1.size() == 0
-	or line_segment2.size() == 0 )
-      return false;
-    if( distance(line_segment1, line_segment2) <= epsilon )
-      return true;
+bool operator==(const Line_Segment &line_segment1,
+                const Line_Segment &line_segment2) {
+  if (line_segment1.size() != line_segment2.size() or
+      line_segment1.size() == 0 or line_segment2.size() == 0)
     return false;
-  }
-
-  
-  bool intersect_proper(const Line_Segment& line_segment1,
-			const Line_Segment& line_segment2, double epsilon)
-  {
-    if( line_segment1.size() == 0
-	or line_segment2.size() == 0 )
-      return false;
-
-    //Declare new vars just for readability.
-    Point a( line_segment1.first()  );
-    Point b( line_segment1.second() );
-    Point c( line_segment2.first()  );
-    Point d( line_segment2.second() );
-    //First find the minimum of the distances between all 4 endpoints_
-    //and their respective projections onto the opposite line segment.
-    double running_min, distance_temp;
-    running_min = distance(a, line_segment2);
-    distance_temp = distance(b, line_segment2);
-    if(distance_temp<running_min)
-      running_min = distance_temp;
-    distance_temp = distance(c, line_segment1);
-    if(distance_temp<running_min)
-      running_min = distance_temp;
-    distance_temp = distance(d, line_segment1);
-    if(distance_temp<running_min)
-      running_min = distance_temp;
-    //If an endpoint is close enough to the other segment, the
-    //intersection is not considered proper.
-    if(running_min <= epsilon)
-      return false; 
-    //This test is from O'Rourke's "Computational Geometry in C",
-    //p.30.  Checks left and right turns.
-    if(  cross(b-a, c-b) * cross(b-a, d-b) < 0   
-	 and   cross(d-c, b-d) * cross(d-c, a-d) < 0  )
-      return true;
+  else if (line_segment1.first() == line_segment2.first() and
+           line_segment1.second() == line_segment2.second())
+    return true;
+  else
     return false;
-  }
+}
 
-  
-  Line_Segment intersection(const Line_Segment& line_segment1,
-			    const Line_Segment& line_segment2, double epsilon)
-  {
-    //Initially empty.
-    Line_Segment line_segment_temp;
+bool operator!=(const Line_Segment &line_segment1,
+                const Line_Segment &line_segment2) {
+  return !(line_segment1 == line_segment2);
+}
 
-    if( line_segment1.size() == 0
-	or line_segment2.size() == 0 )
-      return line_segment_temp;
+bool equivalent(Line_Segment line_segment1, Line_Segment line_segment2,
+                double epsilon) {
+  if (line_segment1.size() != line_segment2.size() or
+      line_segment1.size() == 0 or line_segment2.size() == 0)
+    return false;
+  else if ((distance(line_segment1.first(), line_segment2.first()) <=
+                epsilon and
+            distance(line_segment1.second(), line_segment2.second()) <=
+                epsilon) or
+           (distance(line_segment1.first(), line_segment2.second()) <=
+                epsilon and
+            distance(line_segment1.second(), line_segment2.first()) <= epsilon))
+    return true;
+  else
+    return false;
+}
 
-    //No intersection => return empty segment.
-    if( !intersect(line_segment1, line_segment2, epsilon) )
-       return line_segment_temp;
-    //Declare new vars just for readability.
-    Point a( line_segment1.first()  );
-    Point b( line_segment1.second() );
-    Point c( line_segment2.first()  );
-    Point d( line_segment2.second() );
-    if( intersect_proper(line_segment1, line_segment2, epsilon) ){
-      //Use formula from O'Rourke's "Computational Geometry in C", p. 221.
-      //Note D=0 iff the line segments are parallel.
-      double D = a.x()*( d.y() - c.y() ) 
-	+ b.x()*( c.y() - d.y() ) 
-	+ d.x()*( b.y() - a.y() ) 
-	+ c.x()*( a.y() - b.y() );
-      double s = (  a.x()*( d.y() - c.y() ) 
-		    + c.x()*( a.y() - d.y() ) 
-		    + d.x()*( c.y() - a.y() )  ) / D;
-      line_segment_temp.set_first( a + s * ( b - a ) );
-      return line_segment_temp;
-      }
-    //Otherwise if improper...
-    double distance_temp_a = distance(a,  line_segment2);
-    double distance_temp_b = distance(b, line_segment2);
-    double distance_temp_c = distance(c,  line_segment1);
-    double distance_temp_d = distance(d, line_segment1);
-    //Check if the intersection is nondegenerate segment.
-    if( distance_temp_a <= epsilon  and  distance_temp_b <= epsilon ){
-      line_segment_temp.set_first(a, epsilon);
-      line_segment_temp.set_second(b, epsilon);
-      return line_segment_temp;
+double distance(const Line_Segment &line_segment1,
+                const Line_Segment &line_segment2) {
+  assert(line_segment1.size() > 0 and line_segment2.size() > 0);
+
+  if (intersect_proper(line_segment1, line_segment2))
+    return 0;
+  // But if two line segments intersect improperly, the distance
+  // between them is equal to the minimum of the distances between
+  // all 4 endpoints_ and their respective projections onto the line
+  // segment they don't belong to.
+  double running_min, distance_temp;
+  running_min = distance(line_segment1.first(), line_segment2);
+  distance_temp = distance(line_segment1.second(), line_segment2);
+  if (distance_temp < running_min)
+    running_min = distance_temp;
+  distance_temp = distance(line_segment2.first(), line_segment1);
+  if (distance_temp < running_min)
+    running_min = distance_temp;
+  distance_temp = distance(line_segment2.second(), line_segment1);
+  if (distance_temp < running_min)
+    return distance_temp;
+  return running_min;
+}
+
+double boundary_distance(const Line_Segment &line_segment,
+                         const Polygon &polygon) {
+  assert(line_segment.size() > 0 and polygon.n() > 0);
+
+  double running_min = distance(line_segment, polygon[0]);
+  if (polygon.n() > 1)
+    for (unsigned i = 0; i < polygon.n(); i++) {
+      double d =
+          distance(line_segment, Line_Segment(polygon[i], polygon[i + 1]));
+      if (running_min > d)
+        running_min = d;
     }
-    else if( distance_temp_c <= epsilon  and  distance_temp_d <= epsilon ){
-      line_segment_temp.set_first(c, epsilon);
-      line_segment_temp.set_second(d, epsilon);
-      return line_segment_temp;
-    }
-    else if( distance_temp_a <= epsilon  and  distance_temp_c <= epsilon ){
-      line_segment_temp.set_first(a, epsilon);
-      line_segment_temp.set_second(c, epsilon);
-      return line_segment_temp;
-    }
-    else if( distance_temp_a <= epsilon  and  distance_temp_d <= epsilon ){
-      line_segment_temp.set_first(a, epsilon);
-      line_segment_temp.set_second(d, epsilon);
-      return line_segment_temp;
-    }
-    else if( distance_temp_b <= epsilon  and  distance_temp_c <= epsilon ){
-      line_segment_temp.set_first(b, epsilon);
-      line_segment_temp.set_second(c, epsilon);
-      return line_segment_temp;
-    }
-    else if( distance_temp_b <= epsilon  and  distance_temp_d <= epsilon ){
-      line_segment_temp.set_first(b, epsilon);
-      line_segment_temp.set_second(d, epsilon);
-      return line_segment_temp;
-    }
-    //Check if the intersection is a single point.
-    else if( distance_temp_a <= epsilon ){
-      line_segment_temp.set_first(a, epsilon);
-      return line_segment_temp;
-    }
-    else if( distance_temp_b <= epsilon ){
-      line_segment_temp.set_first(b, epsilon);
-      return line_segment_temp;
-    }
-    else if( distance_temp_c <= epsilon ){
-      line_segment_temp.set_first(c, epsilon);
-      return line_segment_temp;
-    }
-    else if( distance_temp_d <= epsilon ){
-      line_segment_temp.set_first(d, epsilon);
-      return line_segment_temp;
-    }
+  return running_min;
+}
+double boundary_distance(const Polygon &polygon,
+                         const Line_Segment &line_segment) {
+  return boundary_distance(line_segment, polygon);
+}
+
+bool intersect(const Line_Segment &line_segment1,
+               const Line_Segment &line_segment2, double epsilon) {
+  if (line_segment1.size() == 0 or line_segment2.size() == 0)
+    return false;
+  if (distance(line_segment1, line_segment2) <= epsilon)
+    return true;
+  return false;
+}
+
+bool intersect_proper(const Line_Segment &line_segment1,
+                      const Line_Segment &line_segment2, double epsilon) {
+  if (line_segment1.size() == 0 or line_segment2.size() == 0)
+    return false;
+
+  // Declare new vars just for readability.
+  Point a(line_segment1.first());
+  Point b(line_segment1.second());
+  Point c(line_segment2.first());
+  Point d(line_segment2.second());
+  // First find the minimum of the distances between all 4 endpoints_
+  // and their respective projections onto the opposite line segment.
+  double running_min, distance_temp;
+  running_min = distance(a, line_segment2);
+  distance_temp = distance(b, line_segment2);
+  if (distance_temp < running_min)
+    running_min = distance_temp;
+  distance_temp = distance(c, line_segment1);
+  if (distance_temp < running_min)
+    running_min = distance_temp;
+  distance_temp = distance(d, line_segment1);
+  if (distance_temp < running_min)
+    running_min = distance_temp;
+  // If an endpoint is close enough to the other segment, the
+  // intersection is not considered proper.
+  if (running_min <= epsilon)
+    return false;
+  // This test is from O'Rourke's "Computational Geometry in C",
+  // p.30.  Checks left and right turns.
+  if (cross(b - a, c - b) * cross(b - a, d - b) < 0 and
+      cross(d - c, b - d) * cross(d - c, a - d) < 0)
+    return true;
+  return false;
+}
+
+Line_Segment intersection(const Line_Segment &line_segment1,
+                          const Line_Segment &line_segment2, double epsilon) {
+  // Initially empty.
+  Line_Segment line_segment_temp;
+
+  if (line_segment1.size() == 0 or line_segment2.size() == 0)
+    return line_segment_temp;
+
+  // No intersection => return empty segment.
+  if (!intersect(line_segment1, line_segment2, epsilon))
+    return line_segment_temp;
+  // Declare new vars just for readability.
+  Point a(line_segment1.first());
+  Point b(line_segment1.second());
+  Point c(line_segment2.first());
+  Point d(line_segment2.second());
+  if (intersect_proper(line_segment1, line_segment2, epsilon)) {
+    // Use formula from O'Rourke's "Computational Geometry in C", p. 221.
+    // Note D=0 iff the line segments are parallel.
+    double D = a.x() * (d.y() - c.y()) + b.x() * (c.y() - d.y()) +
+               d.x() * (b.y() - a.y()) + c.x() * (a.y() - b.y());
+    double s = (a.x() * (d.y() - c.y()) + c.x() * (a.y() - d.y()) +
+                d.x() * (c.y() - a.y())) /
+               D;
+    line_segment_temp.set_first(a + s * (b - a));
     return line_segment_temp;
   }
+  // Otherwise if improper...
+  double distance_temp_a = distance(a, line_segment2);
+  double distance_temp_b = distance(b, line_segment2);
+  double distance_temp_c = distance(c, line_segment1);
+  double distance_temp_d = distance(d, line_segment1);
+  // Check if the intersection is nondegenerate segment.
+  if (distance_temp_a <= epsilon and distance_temp_b <= epsilon) {
+    line_segment_temp.set_first(a, epsilon);
+    line_segment_temp.set_second(b, epsilon);
+    return line_segment_temp;
+  } else if (distance_temp_c <= epsilon and distance_temp_d <= epsilon) {
+    line_segment_temp.set_first(c, epsilon);
+    line_segment_temp.set_second(d, epsilon);
+    return line_segment_temp;
+  } else if (distance_temp_a <= epsilon and distance_temp_c <= epsilon) {
+    line_segment_temp.set_first(a, epsilon);
+    line_segment_temp.set_second(c, epsilon);
+    return line_segment_temp;
+  } else if (distance_temp_a <= epsilon and distance_temp_d <= epsilon) {
+    line_segment_temp.set_first(a, epsilon);
+    line_segment_temp.set_second(d, epsilon);
+    return line_segment_temp;
+  } else if (distance_temp_b <= epsilon and distance_temp_c <= epsilon) {
+    line_segment_temp.set_first(b, epsilon);
+    line_segment_temp.set_second(c, epsilon);
+    return line_segment_temp;
+  } else if (distance_temp_b <= epsilon and distance_temp_d <= epsilon) {
+    line_segment_temp.set_first(b, epsilon);
+    line_segment_temp.set_second(d, epsilon);
+    return line_segment_temp;
+  }
+  // Check if the intersection is a single point.
+  else if (distance_temp_a <= epsilon) {
+    line_segment_temp.set_first(a, epsilon);
+    return line_segment_temp;
+  } else if (distance_temp_b <= epsilon) {
+    line_segment_temp.set_first(b, epsilon);
+    return line_segment_temp;
+  } else if (distance_temp_c <= epsilon) {
+    line_segment_temp.set_first(c, epsilon);
+    return line_segment_temp;
+  } else if (distance_temp_d <= epsilon) {
+    line_segment_temp.set_first(d, epsilon);
+    return line_segment_temp;
+  }
+  return line_segment_temp;
+}
 
-
-  std::ostream& operator << (std::ostream& outs,
-			     const Line_Segment& line_segment_temp)
-  {
-    switch(line_segment_temp.size()){
-    case 0:
-      return outs;
-      break;
-    case 1:
-      outs << line_segment_temp.first() << std::endl 
-	   << line_segment_temp.second() << std::endl;
-      return outs;
-      break;
-    case 2:
-      outs << line_segment_temp.first() << std::endl 
-	   << line_segment_temp.second() << std::endl;
-      return outs;
-    }
+std::ostream &operator<<(std::ostream &outs,
+                         const Line_Segment &line_segment_temp) {
+  switch (line_segment_temp.size()) {
+  case 0:
+    return outs;
+    break;
+  case 1:
+    outs << line_segment_temp.first() << std::endl
+         << line_segment_temp.second() << std::endl;
+    return outs;
+    break;
+  case 2:
+    outs << line_segment_temp.first() << std::endl
+         << line_segment_temp.second() << std::endl;
     return outs;
   }
+  return outs;
+}
 
+// Angle
 
-  //Angle
-
-
-  Angle::Angle(double data_temp)
-  {
-    if(data_temp >= 0)
-      angle_radians_ = fmod(data_temp, 2*M_PI);
-    else{
-      angle_radians_ = 2*M_PI + fmod(data_temp, -2*M_PI);
-      if(angle_radians_ == 2*M_PI)
-	angle_radians_ = 0;
-    }
-  }
-
-
-  Angle::Angle(double rise_temp, double run_temp)
-  {
-    if( rise_temp == 0 and run_temp == 0 )
+Angle::Angle(double data_temp) {
+  if (data_temp >= 0)
+    angle_radians_ = fmod(data_temp, 2 * M_PI);
+  else {
+    angle_radians_ = 2 * M_PI + fmod(data_temp, -2 * M_PI);
+    if (angle_radians_ == 2 * M_PI)
       angle_radians_ = 0;
-    //First calculate 4 quadrant inverse tangent into [-pi,+pi].
-    angle_radians_ = std::atan2(rise_temp, run_temp);
-    //Correct so angles specified in [0, 2*PI).
-    if(angle_radians_ < 0)
-      angle_radians_ = 2*M_PI + angle_radians_;
   }
+}
 
+Angle::Angle(double rise_temp, double run_temp) {
+  if (rise_temp == 0 and run_temp == 0)
+    angle_radians_ = 0;
+  // First calculate 4 quadrant inverse tangent into [-pi,+pi].
+  angle_radians_ = std::atan2(rise_temp, run_temp);
+  // Correct so angles specified in [0, 2*PI).
+  if (angle_radians_ < 0)
+    angle_radians_ = 2 * M_PI + angle_radians_;
+}
 
-  void Angle::set(double data_temp)
-  { 
-    *this = Angle(data_temp);
+void Angle::set(double data_temp) { *this = Angle(data_temp); }
+
+void Angle::randomize() {
+  angle_radians_ = fmod(uniform_random_sample(0, 2 * M_PI), 2 * M_PI);
+}
+
+bool operator==(const Angle &angle1, const Angle &angle2) {
+  return (angle1.get() == angle2.get());
+}
+bool operator!=(const Angle &angle1, const Angle &angle2) {
+  return !(angle1.get() == angle2.get());
+}
+
+bool operator>(const Angle &angle1, const Angle &angle2) {
+  return angle1.get() > angle2.get();
+}
+bool operator<(const Angle &angle1, const Angle &angle2) {
+  return angle1.get() < angle2.get();
+}
+bool operator>=(const Angle &angle1, const Angle &angle2) {
+  return angle1.get() >= angle2.get();
+}
+bool operator<=(const Angle &angle1, const Angle &angle2) {
+  return angle1.get() <= angle2.get();
+}
+
+Angle operator+(const Angle &angle1, const Angle &angle2) {
+  return Angle(angle1.get() + angle2.get());
+}
+Angle operator-(const Angle &angle1, const Angle &angle2) {
+  return Angle(angle1.get() - angle2.get());
+}
+
+double geodesic_distance(const Angle &angle1, const Angle &angle2) {
+  assert(angle1.get() == angle1.get() and angle2.get() == angle2.get());
+
+  double distance1 = std::fabs(angle1.get() - angle2.get());
+  double distance2 = 2 * M_PI - distance1;
+  if (distance1 < distance2)
+    return distance1;
+  return distance2;
+}
+
+double geodesic_direction(const Angle &angle1, const Angle &angle2) {
+  assert(angle1.get() == angle1.get() and angle2.get() == angle2.get());
+
+  double distance1 = std::fabs(angle1.get() - angle2.get());
+  double distance2 = 2 * M_PI - distance1;
+  if (angle1 <= angle2) {
+    if (distance1 < distance2)
+      return 1.0;
+    return -1.0;
   }
+  // Otherwise angle1 > angle2.
+  if (distance1 < distance2)
+    return -1.0;
+  return 1.0;
+}
 
+std::ostream &operator<<(std::ostream &outs, const Angle &angle_temp) {
+  outs << angle_temp.get();
+  return outs;
+}
 
-  void Angle::randomize()
-  {
-    angle_radians_ = fmod( uniform_random_sample(0, 2*M_PI), 2*M_PI );
+// Polar_Point
+
+Polar_Point::Polar_Point(const Point &polar_origin_temp,
+                         const Point &point_temp, double epsilon)
+    : Point(point_temp) {
+  polar_origin_ = polar_origin_temp;
+  if (polar_origin_ == polar_origin_ and point_temp == point_temp and
+      distance(polar_origin_, point_temp) <= epsilon) {
+    bearing_ = Angle(0.0);
+    range_ = 0.0;
+  } else if (polar_origin_ == polar_origin_ and point_temp == point_temp) {
+    bearing_ = Angle(point_temp.y() - polar_origin_temp.y(),
+                     point_temp.x() - polar_origin_temp.x());
+    range_ = distance(polar_origin_temp, point_temp);
   }
+}
 
+void Polar_Point::set_polar_origin(const Point &polar_origin_temp) {
+  *this = Polar_Point(polar_origin_temp, Point(x(), y()));
+}
 
-  bool operator == (const Angle& angle1, const Angle& angle2)
-  {
-    return (angle1.get() == angle2.get());
-  }
-  bool operator != (const Angle& angle1, const Angle& angle2)
-  {
-    return !(angle1.get() == angle2.get());
-  }
+void Polar_Point::set_x(double x_temp) {
+  *this = Polar_Point(polar_origin_, Point(x_temp, y()));
+}
 
+void Polar_Point::set_y(double y_temp) {
+  *this = Polar_Point(polar_origin_, Point(x(), y_temp));
+}
 
-  bool operator >  (const Angle& angle1, const Angle& angle2)
-  {
-    return angle1.get() > angle2.get();
-  }
-  bool operator <  (const Angle& angle1, const Angle& angle2)
-  {
-    return angle1.get() < angle2.get();
-  }
-  bool operator >= (const Angle& angle1, const Angle& angle2)
-  {
-    return angle1.get() >= angle2.get();
-  }
-  bool operator <= (const Angle& angle1, const Angle& angle2)
-  {
-    return angle1.get() <= angle2.get();
-  }
+void Polar_Point::set_range(double range_temp) {
+  range_ = range_temp;
+  x_ = polar_origin_.x() + range_ * std::cos(bearing_.get());
+  y_ = polar_origin_.y() + range_ * std::sin(bearing_.get());
+}
 
+void Polar_Point::set_bearing(const Angle &bearing_temp) {
+  bearing_ = bearing_temp;
+  x_ = polar_origin_.x() + range_ * std::cos(bearing_.get());
+  y_ = polar_origin_.y() + range_ * std::sin(bearing_.get());
+}
 
-  Angle operator +  (const Angle& angle1, const Angle& angle2)
-  {
-    return Angle( angle1.get()  + angle2.get() );
-  }
-  Angle operator -  (const Angle& angle1, const Angle& angle2)
-  {
-    return Angle( angle1.get() - angle2.get() );
-  }
+bool operator==(const Polar_Point &polar_point1,
+                const Polar_Point &polar_point2) {
+  if (polar_point1.polar_origin() == polar_point2.polar_origin() and
+      polar_point1.range() == polar_point2.range() and
+      polar_point1.bearing() == polar_point2.bearing())
+    return true;
+  return false;
+}
+bool operator!=(const Polar_Point &polar_point1,
+                const Polar_Point &polar_point2) {
+  return !(polar_point1 == polar_point2);
+}
 
-
-  double geodesic_distance(const Angle& angle1, const Angle& angle2)
-  {
-    assert( angle1.get() == angle1.get()
-	    and angle2.get() == angle2.get() );
-
-    double distance1 = std::fabs( angle1.get() 
-				  - angle2.get() );
-    double distance2 = 2*M_PI - distance1;
-    if(distance1 < distance2)
-      return distance1;
-    return distance2;
-  }
-
-
-  double geodesic_direction(const Angle& angle1, const Angle& angle2)
-  {
-    assert( angle1.get() == angle1.get()
-	    and angle2.get() == angle2.get() );
-
-    double distance1 = std::fabs( angle1.get() 
-				  - angle2.get() );
-    double distance2 = 2*M_PI - distance1;
-    if(angle1 <= angle2){
-      if(distance1 < distance2)
-	return 1.0;
-      return -1.0;
-    }
-    //Otherwise angle1 > angle2.
-    if(distance1 < distance2)
-      return -1.0;
-    return 1.0;
-  }
-
-
-  std::ostream& operator << (std::ostream& outs, const Angle& angle_temp)
-  {
-    outs << angle_temp.get();
-    return outs;
-  }
-
-
-  //Polar_Point
-
-
-  Polar_Point::Polar_Point(const Point& polar_origin_temp,
-			   const Point& point_temp,
-			   double epsilon) : Point(point_temp)
-  {
-    polar_origin_ = polar_origin_temp;
-    if( polar_origin_==polar_origin_
-	and point_temp==point_temp
-	and distance(polar_origin_, point_temp) <= epsilon ){
-      bearing_ = Angle(0.0);
-      range_ = 0.0;
-    }
-    else if( polar_origin_==polar_origin_
-	     and point_temp==point_temp){
-      bearing_ = Angle(  point_temp.y()-polar_origin_temp.y(), 
-			 point_temp.x()-polar_origin_temp.x()  );
-      range_ = distance(polar_origin_temp, point_temp);
-    }
-  }
-
-
-  void Polar_Point::set_polar_origin(const Point& polar_origin_temp)
-  {
-    *this = Polar_Point( polar_origin_temp, Point(x(), y()) );
-  }
-
-
-  void Polar_Point::set_x(double x_temp)
-  {
-    *this = Polar_Point( polar_origin_, Point(x_temp, y()) );
-  }
-
-
-  void Polar_Point::set_y(double y_temp)
-  {
-    *this = Polar_Point( polar_origin_, Point(x(), y_temp) );
-  }
-
-
-  void Polar_Point::set_range(double range_temp)
-  {
-    range_ = range_temp;
-    x_ = polar_origin_.x() 
-      + range_*std::cos( bearing_.get() );
-    y_ = polar_origin_.y() 
-      + range_*std::sin( bearing_.get() );
-  }
-
-
-  void Polar_Point::set_bearing(const Angle& bearing_temp)
-  {
-    bearing_ = bearing_temp;
-    x_ = polar_origin_.x() 
-      + range_*std::cos( bearing_.get() );
-    y_ = polar_origin_.y() 
-             + range_*std::sin( bearing_.get() );
-  }
-
-  
-  bool operator == (const Polar_Point& polar_point1,
-		    const Polar_Point& polar_point2)
-  {
-    if( polar_point1.polar_origin() == polar_point2.polar_origin()
-	and polar_point1.range() == polar_point2.range()
-	and polar_point1.bearing() == polar_point2.bearing()
-	)
-      return true;
-    return false;
-  }
-  bool operator != (const Polar_Point& polar_point1,
-		    const Polar_Point& polar_point2)
-  {
-    return !( polar_point1 == polar_point2 );
-  }
-
-
-  bool operator > (const Polar_Point& polar_point1,
-		   const Polar_Point& polar_point2)
-  {
-    if( polar_point1.polar_origin() != polar_point1.polar_origin()
-	or polar_point1.range() != polar_point1.range()
-	or polar_point1.bearing() != polar_point1.bearing() 
-	or polar_point2.polar_origin() != polar_point2.polar_origin()
-	or polar_point2.range() != polar_point2.range()
-	or polar_point2.bearing() != polar_point2.bearing() 
-	)
-      return false;
-
-    if( polar_point1.bearing() > polar_point2.bearing() )
-      return true;
-    else if( polar_point1.bearing() == polar_point2.bearing() 
-	     and  polar_point1.range() > polar_point2.range() )
-      return true;
-    return false;
-  }
-  bool operator < (const Polar_Point& polar_point1,
-		   const Polar_Point& polar_point2)
-  {
-    if( polar_point1.polar_origin() != polar_point1.polar_origin()
-	or polar_point1.range() != polar_point1.range()
-	or polar_point1.bearing() != polar_point1.bearing() 
-	or polar_point2.polar_origin() != polar_point2.polar_origin()
-	or polar_point2.range() != polar_point2.range()
-	or polar_point2.bearing() != polar_point2.bearing() 
-	)
-      return false;
-
-    if( polar_point1.bearing() < polar_point2.bearing() )
-      return true;
-    else if( polar_point1.bearing() == polar_point2.bearing() 
-	     and  polar_point1.range() < polar_point2.range() )
-      return true;
+bool operator>(const Polar_Point &polar_point1,
+               const Polar_Point &polar_point2) {
+  if (polar_point1.polar_origin() != polar_point1.polar_origin() or
+      polar_point1.range() != polar_point1.range() or
+      polar_point1.bearing() != polar_point1.bearing() or
+      polar_point2.polar_origin() != polar_point2.polar_origin() or
+      polar_point2.range() != polar_point2.range() or
+      polar_point2.bearing() != polar_point2.bearing())
     return false;
 
+  if (polar_point1.bearing() > polar_point2.bearing())
+    return true;
+  else if (polar_point1.bearing() == polar_point2.bearing() and
+           polar_point1.range() > polar_point2.range())
+    return true;
+  return false;
+}
+bool operator<(const Polar_Point &polar_point1,
+               const Polar_Point &polar_point2) {
+  if (polar_point1.polar_origin() != polar_point1.polar_origin() or
+      polar_point1.range() != polar_point1.range() or
+      polar_point1.bearing() != polar_point1.bearing() or
+      polar_point2.polar_origin() != polar_point2.polar_origin() or
+      polar_point2.range() != polar_point2.range() or
+      polar_point2.bearing() != polar_point2.bearing())
+    return false;
+
+  if (polar_point1.bearing() < polar_point2.bearing())
+    return true;
+  else if (polar_point1.bearing() == polar_point2.bearing() and
+           polar_point1.range() < polar_point2.range())
+    return true;
+  return false;
+}
+bool operator>=(const Polar_Point &polar_point1,
+                const Polar_Point &polar_point2) {
+  if (polar_point1.polar_origin() != polar_point1.polar_origin() or
+      polar_point1.range() != polar_point1.range() or
+      polar_point1.bearing() != polar_point1.bearing() or
+      polar_point2.polar_origin() != polar_point2.polar_origin() or
+      polar_point2.range() != polar_point2.range() or
+      polar_point2.bearing() != polar_point2.bearing())
+    return false;
+
+  return !(polar_point1 < polar_point2);
+}
+bool operator<=(const Polar_Point &polar_point1,
+                const Polar_Point &polar_point2) {
+  if (polar_point1.polar_origin() != polar_point1.polar_origin() or
+      polar_point1.range() != polar_point1.range() or
+      polar_point1.bearing() != polar_point1.bearing() or
+      polar_point2.polar_origin() != polar_point2.polar_origin() or
+      polar_point2.range() != polar_point2.range() or
+      polar_point2.bearing() != polar_point2.bearing())
+    return false;
+
+  return !(polar_point1 > polar_point2);
+}
+
+std::ostream &operator<<(std::ostream &outs,
+                         const Polar_Point &polar_point_temp) {
+  outs << polar_point_temp.bearing() << "  " << polar_point_temp.range();
+  return outs;
+}
+
+// Ray
+
+Ray::Ray(Point base_point_temp, Point bearing_point) {
+  assert(!(base_point_temp == bearing_point));
+
+  base_point_ = base_point_temp;
+  bearing_ = Angle(bearing_point.y() - base_point_temp.y(),
+                   bearing_point.x() - base_point_temp.x());
+}
+
+bool operator==(const Ray &ray1, const Ray &ray2) {
+  if (ray1.base_point() == ray2.base_point() and
+      ray1.bearing() == ray2.bearing())
+    return true;
+  else
+    return false;
+}
+
+bool operator!=(const Ray &ray1, const Ray &ray2) { return !(ray1 == ray2); }
+
+Line_Segment intersection(const Ray ray_temp,
+                          const Line_Segment &line_segment_temp,
+                          double epsilon) {
+  assert(ray_temp == ray_temp and line_segment_temp.size() > 0);
+
+  // First construct a Line_Segment parallel with the Ray which is so
+  // long, that it's intersection with line_segment_temp will be
+  // equal to the intersection of ray_temp with line_segment_temp.
+  double R = distance(ray_temp.base_point(), line_segment_temp) +
+             line_segment_temp.length();
+  Line_Segment seg_approx = Line_Segment(
+      ray_temp.base_point(),
+      ray_temp.base_point() + Point(R * std::cos(ray_temp.bearing().get()),
+                                    R * std::sin(ray_temp.bearing().get())));
+  Line_Segment intersect_seg =
+      intersection(line_segment_temp, seg_approx, epsilon);
+  // Make sure point closer to ray_temp's base_point is listed first.
+  if (intersect_seg.size() == 2 and
+      distance(intersect_seg.first(), ray_temp.base_point()) >
+          distance(intersect_seg.second(), ray_temp.base_point())) {
+    intersect_seg.reverse();
   }
-  bool operator >= (const Polar_Point& polar_point1,
-		    const Polar_Point& polar_point2)
-  {
-    if( polar_point1.polar_origin() != polar_point1.polar_origin()
-	or polar_point1.range() != polar_point1.range()
-	or polar_point1.bearing() != polar_point1.bearing() 
-	or polar_point2.polar_origin() != polar_point2.polar_origin()
-	or polar_point2.range() != polar_point2.range()
-	or polar_point2.bearing() != polar_point2.bearing() 
-	)
+  return intersect_seg;
+}
+
+Line_Segment intersection(const Line_Segment &line_segment_temp,
+                          const Ray &ray_temp, double epsilon) {
+  return intersection(ray_temp, line_segment_temp, epsilon);
+}
+
+// Polyline
+
+double Polyline::length() const {
+  double length_temp = 0;
+  for (unsigned i = 1; i <= vertices_.size() - 1; i++)
+    length_temp += distance(vertices_[i - 1], vertices_[i]);
+  return length_temp;
+}
+
+double Polyline::diameter() const {
+  // Precondition:  nonempty Polyline.
+  assert(size() > 0);
+
+  double running_max = 0;
+  for (unsigned i = 0; i < size() - 1; i++) {
+    for (unsigned j = i + 1; j < size(); j++) {
+      if (distance((*this)[i], (*this)[j]) > running_max)
+        running_max = distance((*this)[i], (*this)[j]);
+    }
+  }
+  return running_max;
+}
+
+Bounding_Box Polyline::bbox() const {
+  // Precondition:  nonempty Polyline.
+  assert(vertices_.size() > 0);
+
+  Bounding_Box bounding_box;
+  double x_min = vertices_[0].x(), x_max = vertices_[0].x(),
+         y_min = vertices_[0].y(), y_max = vertices_[0].y();
+  for (unsigned i = 1; i < vertices_.size(); i++) {
+    if (x_min > vertices_[i].x()) {
+      x_min = vertices_[i].x();
+    }
+    if (x_max < vertices_[i].x()) {
+      x_max = vertices_[i].x();
+    }
+    if (y_min > vertices_[i].y()) {
+      y_min = vertices_[i].y();
+    }
+    if (y_max < vertices_[i].y()) {
+      y_max = vertices_[i].y();
+    }
+  }
+  bounding_box.x_min = x_min;
+  bounding_box.x_max = x_max;
+  bounding_box.y_min = y_min;
+  bounding_box.y_max = y_max;
+  return bounding_box;
+}
+
+void Polyline::eliminate_redundant_vertices(double epsilon) {
+  // Trivial case
+  if (vertices_.size() < 3)
+    return;
+
+  // Store new minimal length list of vertices
+  std::vector<Point> vertices_temp;
+  vertices_temp.reserve(vertices_.size());
+
+  // Place holders
+  unsigned first = 0;
+  unsigned second = 1;
+  unsigned third = 2;
+
+  // Add first vertex
+  vertices_temp.push_back((*this)[first]);
+
+  while (third < vertices_.size()) {
+    // if second redundant
+    if (distance(Line_Segment((*this)[first], (*this)[third]),
+                 (*this)[second]) <= epsilon) {
+      //=>skip it
+      second = third;
+      third++;
+    }
+    // else second not redundant
+    else {
+      //=>add it.
+      vertices_temp.push_back((*this)[second]);
+      first = second;
+      second = third;
+      third++;
+    }
+  }
+
+  // Add last vertex
+  vertices_temp.push_back(vertices_.back());
+
+  // Update list of vertices
+  vertices_ = vertices_temp;
+}
+
+void Polyline::reverse() { std::reverse(vertices_.begin(), vertices_.end()); }
+
+std::ostream &operator<<(std::ostream &outs, const Polyline &polyline_temp) {
+  for (unsigned i = 0; i < polyline_temp.size(); i++)
+    outs << polyline_temp[i] << std::endl;
+  return outs;
+}
+
+void Polyline::append(const Polyline &polyline) {
+  vertices_.reserve(vertices_.size() + polyline.vertices_.size());
+  for (unsigned i = 0; i < polyline.vertices_.size(); i++) {
+    vertices_.push_back(polyline.vertices_[i]);
+  }
+}
+
+// Polygon
+
+Polygon::Polygon(const std::string &filename) {
+  std::ifstream fin(filename.c_str());
+  // if(fin.fail()) { std::cerr << "\x1b[5;31m" << "Input file
+  // opening failed." << "\x1b[0m\n" << "\a \n"; exit(1);}
+  assert(!fin.fail());
+
+  Point point_temp;
+  double x_temp, y_temp;
+  while (fin >> x_temp and fin >> y_temp) {
+    point_temp.set_x(x_temp);
+    point_temp.set_y(y_temp);
+    vertices_.push_back(point_temp);
+  }
+  fin.close();
+}
+
+Polygon::Polygon(const std::vector<Point> &vertices_temp) {
+  vertices_ = vertices_temp;
+}
+
+Polygon::Polygon(const Point &point0, const Point &point1,
+                 const Point &point2) {
+  vertices_.push_back(point0);
+  vertices_.push_back(point1);
+  vertices_.push_back(point2);
+}
+
+unsigned Polygon::r() const {
+  int r_count = 0;
+  if (vertices_.size() > 1) {
+    // Use cross product to count right turns.
+    for (unsigned i = 0; i <= n() - 1; i++)
+      if (((*this)[i + 1].x() - (*this)[i].x()) *
+                  ((*this)[i + 2].y() - (*this)[i].y()) -
+              ((*this)[i + 1].y() - (*this)[i].y()) *
+                  ((*this)[i + 2].x() - (*this)[i].x()) <
+          0)
+        r_count++;
+    if (area() < 0) {
+      r_count = n() - r_count;
+    }
+  }
+  return r_count;
+}
+
+bool Polygon::is_simple(double epsilon) const {
+
+  if (n() == 0 or n() == 1 or n() == 2)
+    return false;
+
+  // Make sure adjacent edges only intersect at a single point.
+  for (unsigned i = 0; i <= n() - 1; i++)
+    if (intersection(Line_Segment((*this)[i], (*this)[i + 1]),
+                     Line_Segment((*this)[i + 1], (*this)[i + 2]), epsilon)
+            .size() > 1)
       return false;
 
-    return !(polar_point1<polar_point2);
+  // Make sure nonadjacent edges do not intersect.
+  for (unsigned i = 0; i < n() - 2; i++)
+    for (unsigned j = i + 2; j <= n() - 1; j++)
+      if (0 != (j + 1) % vertices_.size() and
+          distance(Line_Segment((*this)[i], (*this)[i + 1]),
+                   Line_Segment((*this)[j], (*this)[j + 1])) <= epsilon)
+        return false;
+
+  return true;
+}
+
+bool Polygon::is_in_standard_form() const {
+  if (vertices_.size() > 1) // if more than one point in the polygon.
+    for (unsigned i = 1; i < vertices_.size(); i++)
+      if (vertices_[0] > vertices_[i])
+        return false;
+  return true;
+}
+
+double Polygon::boundary_length() const {
+  double length_temp = 0;
+  if (n() == 0 or n() == 1)
+    return 0;
+  for (unsigned i = 0; i < n() - 1; i++)
+    length_temp += distance(vertices_[i], vertices_[i + 1]);
+  length_temp += distance(vertices_[n() - 1], vertices_[0]);
+  return length_temp;
+}
+
+double Polygon::area() const {
+  double area_temp = 0;
+  if (n() == 0)
+    return 0;
+  for (unsigned i = 0; i <= n() - 1; i++)
+    area_temp += (*this)[i].x() * (*this)[i + 1].y() -
+                 (*this)[i + 1].x() * (*this)[i].y();
+  return area_temp / 2.0;
+}
+
+Point Polygon::centroid() const {
+  assert(vertices_.size() > 0);
+
+  double area_temp = area();
+  if (area_temp == 0) {
+    std::cerr << "\x1b[5;31m"
+              << "Warning:  tried to compute centoid of polygon with zero area!"
+              << "\x1b[0m\n"
+              << "\a \n";
+    exit(1);
   }
-  bool operator <= (const Polar_Point& polar_point1,
-		    const Polar_Point& polar_point2) 
-  {
-    if( polar_point1.polar_origin() != polar_point1.polar_origin()
-	or polar_point1.range() != polar_point1.range()
-	or polar_point1.bearing() != polar_point1.bearing() 
-	or polar_point2.polar_origin() != polar_point2.polar_origin()
-	or polar_point2.range() != polar_point2.range()
-	or polar_point2.bearing() != polar_point2.bearing() 
-	)
-      return false;
+  double x_temp = 0;
+  for (unsigned i = 0; i <= n() - 1; i++)
+    x_temp += ((*this)[i].x() + (*this)[i + 1].x()) *
+              ((*this)[i].x() * (*this)[i + 1].y() -
+               (*this)[i + 1].x() * (*this)[i].y());
+  double y_temp = 0;
+  for (unsigned i = 0; i <= n() - 1; i++)
+    y_temp += ((*this)[i].y() + (*this)[i + 1].y()) *
+              ((*this)[i].x() * (*this)[i + 1].y() -
+               (*this)[i + 1].x() * (*this)[i].y());
+  return Point(x_temp / (6 * area_temp), y_temp / (6 * area_temp));
+}
 
-    return !(polar_point1>polar_point2);
-  }
+double Polygon::diameter() const {
+  // Precondition:  nonempty Polygon.
+  assert(n() > 0);
 
-
-  std::ostream& operator << (std::ostream& outs,
-			     const Polar_Point& polar_point_temp)
-  {
-    outs << polar_point_temp.bearing() << "  " << polar_point_temp.range();
-    return outs;
-  }
-
-
-  //Ray
-
-
-  Ray::Ray(Point base_point_temp, Point bearing_point)
-  { 
-      assert(  !( base_point_temp == bearing_point )  ); 
-
-      base_point_ = base_point_temp;
-      bearing_ = Angle( bearing_point.y()-base_point_temp.y(),
-			    bearing_point.x()-base_point_temp.x() );
+  double running_max = 0;
+  for (unsigned i = 0; i < n() - 1; i++) {
+    for (unsigned j = i + 1; j < n(); j++) {
+      if (distance((*this)[i], (*this)[j]) > running_max)
+        running_max = distance((*this)[i], (*this)[j]);
     }
-
-  bool operator == (const Ray& ray1,
-		    const Ray& ray2)
-  {
-    if( ray1.base_point() == ray2.base_point()
-	and ray1.bearing() == ray2.bearing() )
-      return true;
-    else
-      return false;
   }
+  return running_max;
+}
 
+Bounding_Box Polygon::bbox() const {
+  // Precondition:  nonempty Polygon.
+  assert(vertices_.size() > 0);
 
-  bool operator != (const Ray& ray1,
-		    const Ray& ray2)
-  {
-    return !( ray1 == ray2 );
-  }
-
-
-  Line_Segment intersection(const Ray ray_temp,
-			    const Line_Segment& line_segment_temp,
-			    double epsilon)
-  {
-    assert( ray_temp == ray_temp
-	    and line_segment_temp.size() > 0 );
-
-    //First construct a Line_Segment parallel with the Ray which is so
-    //long, that it's intersection with line_segment_temp will be
-    //equal to the intersection of ray_temp with line_segment_temp.
-    double R = distance(ray_temp.base_point(), line_segment_temp) 
-               + line_segment_temp.length();
-    Line_Segment seg_approx =
-      Line_Segment(  ray_temp.base_point(), ray_temp.base_point() +
-		     Point( R*std::cos(ray_temp.bearing().get()),
-			    R*std::sin(ray_temp.bearing().get()) )  );
-    Line_Segment intersect_seg = intersection(line_segment_temp,
-					      seg_approx,
-					      epsilon);
-    //Make sure point closer to ray_temp's base_point is listed first.
-    if( intersect_seg.size() == 2
-	and distance( intersect_seg.first(), ray_temp.base_point() ) >
-	distance( intersect_seg.second(), ray_temp.base_point() )  ){
-      intersect_seg.reverse();
+  Bounding_Box bounding_box;
+  double x_min = vertices_[0].x(), x_max = vertices_[0].x(),
+         y_min = vertices_[0].y(), y_max = vertices_[0].y();
+  for (unsigned i = 1; i < vertices_.size(); i++) {
+    if (x_min > vertices_[i].x()) {
+      x_min = vertices_[i].x();
     }
-    return intersect_seg;
-  }
-
-
-  Line_Segment intersection(const Line_Segment& line_segment_temp,
-			    const Ray& ray_temp,
-			    double epsilon)
-  {
-    return intersection( ray_temp , line_segment_temp , epsilon );
-  }
-
-
-  //Polyline
-
-
-  double Polyline::length() const
-  {
-    double length_temp = 0;
-    for(unsigned i=1; i <= vertices_.size()-1; i++)
-      length_temp += distance( vertices_[i-1] , vertices_[i] );
-    return length_temp;
-  }
-
-
-  double Polyline::diameter() const
-  {
-    //Precondition:  nonempty Polyline.
-    assert( size() > 0 );
-
-    double running_max=0;
-    for(unsigned i=0; i<size()-1; i++){
-    for(unsigned j=i+1; j<size(); j++){
-      if( distance( (*this)[i] , (*this)[j] ) > running_max )
-	running_max = distance( (*this)[i] , (*this)[j] );
-    }}
-    return running_max;
-  }
-
-
-  Bounding_Box Polyline::bbox () const
-  {
-    //Precondition:  nonempty Polyline.
-    assert( vertices_.size() > 0 );
-
-    Bounding_Box bounding_box;
-    double x_min=vertices_[0].x(), x_max=vertices_[0].x(),
-      y_min=vertices_[0].y(), y_max=vertices_[0].y();
-    for(unsigned i = 1; i <  vertices_.size(); i++){
-      if(x_min > vertices_[i].x())  { x_min=vertices_[i].x(); }
-      if(x_max < vertices_[i].x())  { x_max=vertices_[i].x(); }
-      if(y_min > vertices_[i].y())  { y_min=vertices_[i].y(); }
-      if(y_max < vertices_[i].y())  { y_max=vertices_[i].y(); }
+    if (x_max < vertices_[i].x()) {
+      x_max = vertices_[i].x();
     }
-    bounding_box.x_min=x_min; bounding_box.x_max=x_max;
-    bounding_box.y_min=y_min; bounding_box.y_max=y_max;
-    return bounding_box;
+    if (y_min > vertices_[i].y()) {
+      y_min = vertices_[i].y();
+    }
+    if (y_max < vertices_[i].y()) {
+      y_max = vertices_[i].y();
+    }
   }
+  bounding_box.x_min = x_min;
+  bounding_box.x_max = x_max;
+  bounding_box.y_min = y_min;
+  bounding_box.y_max = y_max;
+  return bounding_box;
+}
 
+std::vector<Point> Polygon::random_points(const unsigned &count,
+                                          double epsilon) const {
+  // Precondition:  nonempty Polygon.
+  assert(vertices_.size() > 0);
 
-  void Polyline::eliminate_redundant_vertices(double epsilon)
-  {
-    //Trivial case
-    if(vertices_.size() < 3)
-      return;
+  Bounding_Box bounding_box = bbox();
+  std::vector<Point> pts_in_polygon;
+  pts_in_polygon.reserve(count);
+  Point pt_temp(uniform_random_sample(bounding_box.x_min, bounding_box.x_max),
+                uniform_random_sample(bounding_box.y_min, bounding_box.y_max));
+  while (pts_in_polygon.size() < count) {
+    while (!pt_temp.in(*this, epsilon)) {
+      pt_temp.set_x(
+          uniform_random_sample(bounding_box.x_min, bounding_box.x_max));
+      pt_temp.set_y(
+          uniform_random_sample(bounding_box.y_min, bounding_box.y_max));
+    }
+    pts_in_polygon.push_back(pt_temp);
+    pt_temp.set_x(
+        uniform_random_sample(bounding_box.x_min, bounding_box.x_max));
+    pt_temp.set_y(
+        uniform_random_sample(bounding_box.y_min, bounding_box.y_max));
+  }
+  return pts_in_polygon;
+}
 
-    //Store new minimal length list of vertices
+void Polygon::write_to_file(const std::string &filename,
+                            int fios_precision_temp) {
+  assert(fios_precision_temp >= 1);
+
+  std::ofstream fout(filename.c_str());
+  // fout.open( filename.c_str() );  //Alternatives.
+  // fout << *this;
+  fout.setf(std::ios::fixed);
+  fout.setf(std::ios::showpoint);
+  fout.precision(fios_precision_temp);
+  for (unsigned i = 0; i < n(); i++)
+    fout << vertices_[i] << std::endl;
+  fout.close();
+}
+
+void Polygon::enforce_standard_form() {
+  int point_count = vertices_.size();
+  if (point_count > 1) { // if more than one point in the polygon.
     std::vector<Point> vertices_temp;
-    vertices_temp.reserve(vertices_.size());
-
-    //Place holders
-    unsigned first  = 0;
-    unsigned second = 1;
-    unsigned third  = 2;
-
-    //Add first vertex
-    vertices_temp.push_back((*this)[first]);
-
-    while( third < vertices_.size() ){
-      //if second redundant
-      if(   distance(  Line_Segment( (*this)[first], 
-				     (*this)[third] ) ,
-		       (*this)[second]  ) 
-	    <= epsilon   ){
-	//=>skip it
-	second = third;
-	third++;
-      }
-      //else second not redundant
-      else{
-	//=>add it.
-	vertices_temp.push_back((*this)[second]);
-	first = second;
-	second = third;
-	third++;
-      }
-    }
-
-    //Add last vertex
-    vertices_temp.push_back(vertices_.back());
-
-    //Update list of vertices
+    vertices_temp.reserve(point_count);
+    // Find index of lexicographically smallest point.
+    int index_of_smallest = 0;
+    int i; // counter.
+    for (i = 1; i < point_count; i++)
+      if (vertices_[i] < vertices_[index_of_smallest])
+        index_of_smallest = i;
+    // Fill vertices_temp starting with lex. smallest.
+    for (i = index_of_smallest; i < point_count; i++)
+      vertices_temp.push_back(vertices_[i]);
+    for (i = 0; i < index_of_smallest; i++)
+      vertices_temp.push_back(vertices_[i]);
     vertices_ = vertices_temp;
   }
+}
 
+void Polygon::eliminate_redundant_vertices(double epsilon) {
+  // Degenerate case.
+  if (vertices_.size() < 4)
+    return;
 
-  void Polyline::reverse()
-  {
-    std::reverse( vertices_.begin() , vertices_.end() );
-  }
+  // Store new minimal length list of vertices.
+  std::vector<Point> vertices_temp;
+  vertices_temp.reserve(vertices_.size());
 
+  // Place holders.
+  unsigned first = 0;
+  unsigned second = 1;
+  unsigned third = 2;
 
-  std::ostream& operator << (std::ostream& outs,
-			     const Polyline& polyline_temp)
-  {
-    for(unsigned i=0; i<polyline_temp.size(); i++)
-      outs << polyline_temp[i] << std::endl;
-    return outs;
-  }
-
-
-  void Polyline::append( const Polyline& polyline ){
-    vertices_.reserve( vertices_.size() + polyline.vertices_.size() );
-    for(unsigned i=0; i<polyline.vertices_.size(); i++){
-      vertices_.push_back( polyline.vertices_[i] );
+  while (third <= vertices_.size()) {
+    // if second is redundant
+    if (distance(Line_Segment((*this)[first], (*this)[third]),
+                 (*this)[second]) <= epsilon) {
+      //=>skip it
+      second = third;
+      third++;
+    }
+    // else second not redundant
+    else {
+      //=>add it
+      vertices_temp.push_back((*this)[second]);
+      first = second;
+      second = third;
+      third++;
     }
   }
 
+  // decide whether to add original first point
+  if (distance(Line_Segment(vertices_temp.front(), vertices_temp.back()),
+               vertices_.front()) > epsilon)
+    vertices_temp.push_back(vertices_.front());
 
-  //Polygon
+  // Update list of vertices.
+  vertices_ = vertices_temp;
+}
 
+void Polygon::reverse() {
+  if (n() > 2)
+    std::reverse(++vertices_.begin(), vertices_.end());
+}
 
-  Polygon::Polygon (const std::string& filename)
-  {
-    std::ifstream fin(filename.c_str());
-    //if(fin.fail()) { std::cerr << "\x1b[5;31m" << "Input file
-    //opening failed." << "\x1b[0m\n" << "\a \n"; exit(1);}
-    assert( !fin.fail() );
-
-    Point point_temp;
-    double x_temp, y_temp;
-    while (fin >> x_temp and fin >> y_temp){
-      point_temp.set_x(x_temp);
-      point_temp.set_y(y_temp);
-      vertices_.push_back(point_temp);
-    }
-    fin.close();
-  }
-
-
-  Polygon::Polygon(const std::vector<Point>& vertices_temp)
-  {
-    vertices_ = vertices_temp; 
-  }
-
-
-  Polygon::Polygon(const Point& point0,
-		   const Point& point1,
-		   const Point& point2)
-  {
-    vertices_.push_back(point0);
-    vertices_.push_back(point1);
-    vertices_.push_back(point2);
-  }
-
-
-  unsigned  Polygon::r () const
-  {
-    int r_count = 0;
-    if( vertices_.size() > 1 ){
-      //Use cross product to count right turns.
-      for(unsigned i=0; i<=n()-1; i++)
-	if( ((*this)[i+1].x()-(*this)[i].x())
-	    *((*this)[i+2].y()-(*this)[i].y()) 
-	    - ((*this)[i+1].y()-(*this)[i].y())
-	    *((*this)[i+2].x()-(*this)[i].x()) < 0 )
-	  r_count++;
-      if( area() < 0 ){ 
-	r_count = n() - r_count;
-      }
-    }
-    return r_count;
-  }
-
-
-  bool Polygon::is_simple(double epsilon) const
-  {
-    
-    if(n()==0 or n()==1 or n()==2)
+bool operator==(Polygon polygon1, Polygon polygon2) {
+  if (polygon1.n() != polygon2.n() or polygon1.n() == 0 or polygon2.n() == 0)
+    return false;
+  for (unsigned i = 0; i < polygon1.n(); i++)
+    if (!(polygon1[i] == polygon2[i]))
       return false;
-
-    //Make sure adjacent edges only intersect at a single point.
-    for(unsigned i=0; i<=n()-1; i++)
-      if(  intersection( Line_Segment((*this)[i],(*this)[i+1]) , 
-			 Line_Segment((*this)[i+1],(*this)[i+2]) , 
-			 epsilon ).size() > 1  )
-	return false;
-
-    //Make sure nonadjacent edges do not intersect.
-    for(unsigned i=0; i<n()-2; i++)
-      for(unsigned j=i+2; j<=n()-1; j++)
-	if( 0!=(j+1)%vertices_.size()  
-	    and distance( Line_Segment((*this)[i],(*this)[i+1]) , 
-			  Line_Segment((*this)[j],(*this)[j+1]) ) <= epsilon  )
-	  return false;
-    
-    return true;
-  }
-
-
-  bool Polygon::is_in_standard_form() const
-  {
-    if(vertices_.size() > 1)  //if more than one point in the polygon.
-      for(unsigned i=1; i<vertices_.size(); i++)
-	if(vertices_[0] > vertices_[i])
-	  return false;
-    return true;
-  }
-
-
-  double Polygon::boundary_length() const
-  {
-    double length_temp=0;
-    if(n()==0 or n()==1)
-      return 0;
-    for(unsigned i=0; i<n()-1; i++)
-      length_temp += distance( vertices_[i] , vertices_[i+1] );
-    length_temp += distance( vertices_[n()-1] , 
-			     vertices_[0] );
-    return length_temp;
-  }
-
-
-  double Polygon::area() const
-  {
-    double area_temp = 0;
-    if(n()==0)
-      return 0;
-    for(unsigned i=0; i<=n()-1; i++)
-      area_temp += (*this)[i].x()*(*this)[i+1].y() 
-	- (*this)[i+1].x()*(*this)[i].y();
-    return area_temp/2.0;
-  }
-
-
-  Point Polygon::centroid() const
-  {
-    assert( vertices_.size() > 0 );
-
-    double area_temp=area();
-    if(area_temp==0)
-      { std::cerr << "\x1b[5;31m" 
-	 << "Warning:  tried to compute centoid of polygon with zero area!" 
-	 << "\x1b[0m\n" << "\a \n"; exit(1); } 
-    double x_temp=0;
-    for(unsigned i=0; i<=n()-1; i++)
-      x_temp += ( (*this)[i].x() + (*this)[i+1].x() ) 
-	* ( (*this)[i].x()*(*this)[i+1].y() 
-	    - (*this)[i+1].x()*(*this)[i].y() );
-    double y_temp=0;
-    for(unsigned i=0; i<=n()-1; i++)
-      y_temp += ( (*this)[i].y() + (*this)[i+1].y() ) 
-	* ( (*this)[i].x()*(*this)[i+1].y() 
-	    - (*this)[i+1].x()*(*this)[i].y() );
-    return Point(x_temp/(6*area_temp), y_temp/(6*area_temp));
-  }
-
-
-  double Polygon::diameter() const
-  {
-    //Precondition:  nonempty Polygon.
-    assert( n() > 0 );
-
-    double running_max=0;
-    for(unsigned i=0; i<n()-1; i++){
-    for(unsigned j=i+1; j<n(); j++){
-      if( distance( (*this)[i] , (*this)[j] ) > running_max )
-	running_max = distance( (*this)[i] , (*this)[j] );
-    }}
-    return running_max;
-  }
-
-
-  Bounding_Box Polygon::bbox () const
-  {
-    //Precondition:  nonempty Polygon.
-    assert( vertices_.size() > 0 );
-
-    Bounding_Box bounding_box;
-    double x_min=vertices_[0].x(), x_max=vertices_[0].x(),
-      y_min=vertices_[0].y(), y_max=vertices_[0].y();
-    for(unsigned i = 1; i <  vertices_.size(); i++){
-      if(x_min > vertices_[i].x())  { x_min=vertices_[i].x(); }
-      if(x_max < vertices_[i].x())  { x_max=vertices_[i].x(); }
-      if(y_min > vertices_[i].y())  { y_min=vertices_[i].y(); }
-      if(y_max < vertices_[i].y())  { y_max=vertices_[i].y(); }
-    }
-    bounding_box.x_min=x_min; bounding_box.x_max=x_max;
-    bounding_box.y_min=y_min; bounding_box.y_max=y_max;
-    return bounding_box;
-  }
-
-
-  std::vector<Point> Polygon::random_points(const unsigned& count,
-					    double epsilon) const
-  {
-    //Precondition:  nonempty Polygon.
-    assert( vertices_.size() > 0 );
-
-    Bounding_Box bounding_box = bbox();
-    std::vector<Point> pts_in_polygon; pts_in_polygon.reserve(count);
-    Point pt_temp( uniform_random_sample(bounding_box.x_min, 
-					 bounding_box.x_max),
-		   uniform_random_sample(bounding_box.y_min, 
-					 bounding_box.y_max) );
-    while(pts_in_polygon.size() < count){
-      while(!pt_temp.in(*this, epsilon)){
-	pt_temp.set_x( uniform_random_sample(bounding_box.x_min, 
-					     bounding_box.x_max) );
-	pt_temp.set_y( uniform_random_sample(bounding_box.y_min, 
-					     bounding_box.y_max) );
+  return true;
+}
+bool operator!=(Polygon polygon1, Polygon polygon2) {
+  return !(polygon1 == polygon2);
+}
+bool equivalent(Polygon polygon1, Polygon polygon2, double epsilon) {
+  if (polygon1.n() == 0 or polygon2.n() == 0)
+    return false;
+  if (polygon1.n() != polygon2.n())
+    return false;
+  // Try all cyclic matches
+  unsigned n = polygon1.n(); //=polygon2.n()
+  for (unsigned offset = 0; offset < n; offset++) {
+    bool successful_match = true;
+    for (unsigned i = 0; i < n; i++) {
+      if (distance(polygon1[i], polygon2[i + offset]) > epsilon) {
+        successful_match = false;
+        break;
       }
-      pts_in_polygon.push_back(pt_temp);
-      pt_temp.set_x( uniform_random_sample(bounding_box.x_min, 
-					   bounding_box.x_max) );
-      pt_temp.set_y( uniform_random_sample(bounding_box.y_min, 
-					   bounding_box.y_max) );
     }
-    return pts_in_polygon;
+    if (successful_match)
+      return true;
   }
+  return false;
+}
 
+double boundary_distance(const Polygon &polygon1, const Polygon &polygon2) {
+  assert(polygon1.n() > 0 and polygon2.n() > 0);
 
-  void Polygon::write_to_file(const std::string& filename,
-			      int fios_precision_temp)
-  {
-    assert( fios_precision_temp >= 1 );
-
-    std::ofstream fout( filename.c_str() );
-    //fout.open( filename.c_str() );  //Alternatives.
-    //fout << *this;
-    fout.setf(std::ios::fixed);
-    fout.setf(std::ios::showpoint);
-    fout.precision(fios_precision_temp);
-    for(unsigned i=0; i<n(); i++)
-      fout << vertices_[i] << std::endl;
-    fout.close();
-  }
-
-
-  void Polygon::enforce_standard_form()
-  {
-    int point_count=vertices_.size();
-    if(point_count > 1){ //if more than one point in the polygon.
-      std::vector<Point> vertices_temp;
-      vertices_temp.reserve(point_count);
-      //Find index of lexicographically smallest point.
-      int index_of_smallest=0;
-      int i; //counter.
-      for(i=1; i<point_count; i++)
-	if(vertices_[i]<vertices_[index_of_smallest])
-	  index_of_smallest=i;
-      //Fill vertices_temp starting with lex. smallest.
-      for(i=index_of_smallest; i<point_count; i++)
-	vertices_temp.push_back(vertices_[i]);
-      for(i=0; i<index_of_smallest; i++)
-	vertices_temp.push_back(vertices_[i]);
-      vertices_=vertices_temp;
+  // Handle single point degeneracy.
+  if (polygon1.n() == 1)
+    return boundary_distance(polygon1[0], polygon2);
+  else if (polygon2.n() == 1)
+    return boundary_distance(polygon2[0], polygon1);
+  // Handle cases where each polygon has at least 2 points.
+  // Initialize to an upper bound.
+  double running_min = boundary_distance(polygon1[0], polygon2);
+  double distance_temp;
+  // Loop over all possible pairs of line segments.
+  for (unsigned i = 0; i <= polygon1.n() - 1; i++) {
+    for (unsigned j = 0; j <= polygon2.n() - 1; j++) {
+      distance_temp = distance(Line_Segment(polygon1[i], polygon1[i + 1]),
+                               Line_Segment(polygon2[j], polygon2[j + 1]));
+      if (distance_temp < running_min)
+        running_min = distance_temp;
     }
   }
+  return running_min;
+}
 
+std::ostream &operator<<(std::ostream &outs, const Polygon &polygon_temp) {
+  for (unsigned i = 0; i < polygon_temp.n(); i++)
+    outs << polygon_temp[i] << std::endl;
+  return outs;
+}
 
-  void Polygon::eliminate_redundant_vertices(double epsilon)
-  {
-    //Degenerate case.
-    if( vertices_.size() < 4 )
+// Environment
+
+Environment::Environment(const std::vector<Polygon> &polygons) {
+  outer_boundary_ = polygons[0];
+  for (unsigned i = 1; i < polygons.size(); i++)
+    holes_.push_back(polygons[i]);
+  update_flattened_index_key();
+}
+Environment::Environment(const std::string &filename) {
+  std::ifstream fin(filename.c_str());
+  // if(fin.fail()) { std::cerr << "\x1b[5;31m" << "Input file
+  // opening failed." << "\x1b[0m\n" << "\a \n"; exit(1);}
+  assert(!fin.fail());
+
+  // Temporary vars for numbers to be read from file.
+  double x_temp, y_temp;
+  std::vector<Point> vertices_temp;
+
+  // Skip comments
+  while (fin.peek() == '/')
+    fin.ignore(200, '\n');
+
+  // Read outer_boundary.
+  while (fin.peek() != '/') {
+    fin >> x_temp >> y_temp;
+    // Skip to next line.
+    fin.ignore(1);
+    if (fin.eof()) {
+      outer_boundary_.set_vertices(vertices_temp);
+      fin.close();
+      update_flattened_index_key();
       return;
-
-    //Store new minimal length list of vertices.
-    std::vector<Point> vertices_temp;
-    vertices_temp.reserve( vertices_.size() );
- 
-    //Place holders.
-    unsigned first  = 0;
-    unsigned second = 1;
-    unsigned third  = 2;
-
-    while( third <= vertices_.size() ){
-      //if second is redundant
-      if(   distance(  Line_Segment( (*this)[first], 
-				     (*this)[third] ) ,
-		       (*this)[second]  ) 
-	    <= epsilon   ){
-	//=>skip it
-	second = third;
-	third++;
-      }
-      //else second not redundant
-      else{
-	//=>add it
-	vertices_temp.push_back( (*this)[second] );
-	first = second;
-	second = third;
-	third++;
-      }
     }
-
-    //decide whether to add original first point
-    if(   distance(  Line_Segment( vertices_temp.front(), 
-				   vertices_temp.back() ) ,
-		     vertices_.front()  ) 
-	  > epsilon   )
-      vertices_temp.push_back( vertices_.front() );
-    
-    //Update list of vertices.
-    vertices_ = vertices_temp;   
+    vertices_temp.push_back(Point(x_temp, y_temp));
   }
+  outer_boundary_.set_vertices(vertices_temp);
+  vertices_temp.clear();
 
-
-  void Polygon::reverse()
-  {
-    if( n() > 2 )
-      std::reverse( ++vertices_.begin() , vertices_.end() );
-  }
-
-
-  bool operator == (Polygon polygon1, Polygon polygon2)
-  {
-    if( polygon1.n() != polygon2.n() 
-	or polygon1.n() == 0
-	or polygon2.n() == 0 )
-      return false;
-    for(unsigned i=0; i<polygon1.n(); i++)
-      if(  !(polygon1[i] == polygon2[i])  )
-	return false;
-    return true;
-  }
-  bool operator != (Polygon polygon1, Polygon polygon2)
-  {
-    return !( polygon1 == polygon2 );
-  }
-  bool equivalent(Polygon polygon1, Polygon polygon2, double epsilon)
-  {
-    if( polygon1.n() == 0 or polygon2.n() == 0 )
-      return false;
-    if( polygon1.n() != polygon2.n() )
-      return false;
-    //Try all cyclic matches
-    unsigned n = polygon1.n();//=polygon2.n()
-    for( unsigned offset = 0 ; offset < n ; offset++ ){
-      bool successful_match = true;
-      for(unsigned i=0; i<n; i++){
-	if(  distance( polygon1[ i ] , polygon2[ i + offset ] ) > epsilon  )
-	  { successful_match = false; break; }
-      }
-      if( successful_match )
-	return true;
+  // Read holes.
+  Polygon polygon_temp;
+  while (1) {
+    // Skip comments
+    while (fin.peek() == '/')
+      fin.ignore(200, '\n');
+    if (fin.eof()) {
+      fin.close();
+      update_flattened_index_key();
+      return;
     }
+    while (fin.peek() != '/') {
+      fin >> x_temp >> y_temp;
+      if (fin.eof()) {
+        polygon_temp.set_vertices(vertices_temp);
+        holes_.push_back(polygon_temp);
+        fin.close();
+        update_flattened_index_key();
+        return;
+      }
+      vertices_temp.push_back(Point(x_temp, y_temp));
+      // Skips to next line.
+      fin.ignore(1);
+    }
+    polygon_temp.set_vertices(vertices_temp);
+    holes_.push_back(polygon_temp);
+    vertices_temp.clear();
+  }
+
+  update_flattened_index_key();
+}
+
+const Point &Environment::operator()(unsigned k) const {
+  // std::pair<unsigned,unsigned> ij(one_to_two(k));
+  std::pair<unsigned, unsigned> ij(flattened_index_key_[k]);
+  return (*this)[ij.first][ij.second];
+}
+
+unsigned Environment::n() const {
+  int n_count = 0;
+  n_count = outer_boundary_.n();
+  for (unsigned i = 0; i < h(); i++)
+    n_count += holes_[i].n();
+  return n_count;
+}
+
+unsigned Environment::r() const {
+  int r_count = 0;
+  Polygon polygon_temp;
+  r_count = outer_boundary_.r();
+  for (unsigned i = 0; i < h(); i++) {
+    r_count += holes_[i].n() - holes_[i].r();
+  }
+  return r_count;
+}
+
+bool Environment::is_in_standard_form() const {
+  if (outer_boundary_.is_in_standard_form() == false or
+      outer_boundary_.area() < 0)
+    return false;
+  for (unsigned i = 0; i < holes_.size(); i++)
+    if (holes_[i].is_in_standard_form() == false or holes_[i].area() > 0)
+      return false;
+  return true;
+}
+
+bool Environment::is_valid(double epsilon) const {
+  if (n() <= 2)
+    return false;
+
+  // Check all Polygons are simple.
+  if (!outer_boundary_.is_simple(epsilon)) {
+    std::cerr << std::endl
+              << "\x1b[31m"
+              << "The outer boundary is not simple."
+              << "\x1b[0m" << std::endl;
     return false;
   }
-
-
-  double boundary_distance(const Polygon& polygon1, const Polygon& polygon2)
-  {
-    assert( polygon1.n() > 0  and  polygon2.n() > 0 );
-
-    //Handle single point degeneracy.
-    if(polygon1.n() == 1)
-      return boundary_distance(polygon1[0], polygon2);
-    else if(polygon2.n() == 1)
-      return boundary_distance(polygon2[0], polygon1);
-    //Handle cases where each polygon has at least 2 points.
-    //Initialize to an upper bound.
-    double running_min = boundary_distance(polygon1[0], polygon2);
-    double distance_temp;
-    //Loop over all possible pairs of line segments.
-    for(unsigned i=0; i<=polygon1.n()-1; i++){
-    for(unsigned j=0; j<=polygon2.n()-1; j++){
-      distance_temp = distance( Line_Segment(polygon1[i], polygon1[i+1]) ,
-				Line_Segment(polygon2[j], polygon2[j+1]) );
-      if(distance_temp < running_min)
-	running_min = distance_temp;
-    }}
-    return running_min;
-  }
-
-
-  std::ostream& operator << (std::ostream& outs,
-			     const Polygon& polygon_temp)
-  {
-    for(unsigned i=0; i<polygon_temp.n(); i++)
-      outs << polygon_temp[i] << std::endl;
-    return outs;
-  }
-
-
-  //Environment
-  
-  
-  Environment::Environment(const std::vector<Polygon>& polygons)
-  {
-    outer_boundary_ = polygons[0];
-    for(unsigned i=1; i<polygons.size(); i++)
-      holes_.push_back( polygons[i] );
-    update_flattened_index_key();
-  }
-  Environment::Environment(const std::string& filename)
-  {
-    std::ifstream fin(filename.c_str());
-    //if(fin.fail()) { std::cerr << "\x1b[5;31m" << "Input file
-    //opening failed." << "\x1b[0m\n" << "\a \n"; exit(1);}
-    assert( !fin.fail() );
-
-    //Temporary vars for numbers to be read from file.
-    double x_temp, y_temp;  
-    std::vector<Point> vertices_temp;
-
-    //Skip comments
-    while( fin.peek() == '/' ) 
-      fin.ignore(200,'\n');
-
-    //Read outer_boundary.
-    while ( fin.peek() != '/' ){
-      fin >> x_temp >> y_temp;
-      //Skip to next line.
-      fin.ignore(1);
-      if( fin.eof() )
-	{ 
-	  outer_boundary_.set_vertices(vertices_temp);
-	  fin.close(); 
-	  update_flattened_index_key(); return;
-	}      
-      vertices_temp.push_back( Point(x_temp, y_temp) );
-    }
-    outer_boundary_.set_vertices(vertices_temp);
-    vertices_temp.clear();
-    
-    //Read holes.
-    Polygon polygon_temp;
-    while(1){
-      //Skip comments
-      while( fin.peek() == '/' )
-	fin.ignore(200,'\n');
-      if( fin.eof() )
-	{ fin.close(); update_flattened_index_key(); return; }
-      while( fin.peek() != '/' ){	
-	fin >> x_temp >> y_temp;
-	if( fin.eof() )
-	  { 
-	    polygon_temp.set_vertices(vertices_temp);
-	    holes_.push_back(polygon_temp);
-	    fin.close(); 
-	    update_flattened_index_key(); return;
-	  }
-	vertices_temp.push_back( Point(x_temp, y_temp) );
-	//Skips to next line.
-	fin.ignore(1);
-      }
-      polygon_temp.set_vertices(vertices_temp);
-      holes_.push_back(polygon_temp);
-      vertices_temp.clear();
-    }
-
-    update_flattened_index_key();
-  }
-
-
-  const Point& Environment::operator () (unsigned k) const
-  {
-    //std::pair<unsigned,unsigned> ij(one_to_two(k));
-    std::pair<unsigned,unsigned> ij( flattened_index_key_[k] );
-    return (*this)[ ij.first ][ ij.second ];
-  }
-
-
-  unsigned Environment::n() const
-  {
-    int n_count = 0;
-    n_count = outer_boundary_.n();
-    for(unsigned i=0; i<h(); i++)
-      n_count += holes_[i].n();
-    return n_count;
-  }
-
-
-  unsigned Environment::r() const
-  {
-    int r_count = 0;
-    Polygon polygon_temp;
-    r_count = outer_boundary_.r();
-    for(unsigned i=0; i<h(); i++){
-      r_count +=  holes_[i].n() - holes_[i].r();
-    }
-    return r_count;
-  }
-
-
-  bool Environment::is_in_standard_form() const
-  {
-    if( outer_boundary_.is_in_standard_form() == false 
-	or outer_boundary_.area() < 0 )
-      return false;
-    for(unsigned i=0; i<holes_.size(); i++)
-      if( holes_[i].is_in_standard_form() == false 
-	  or holes_[i].area() > 0 )
-	return false;
-    return true;
-  }
-
-  
-  bool Environment::is_valid(double epsilon) const
-  {
-    if( n() <= 2 )
-      return false;
-
-    //Check all Polygons are simple.
-    if( !outer_boundary_.is_simple(epsilon) ){
-      std::cerr << std::endl << "\x1b[31m" 
-		<< "The outer boundary is not simple." 
-		<<  "\x1b[0m" << std::endl;
+  for (unsigned i = 0; i < h(); i++)
+    if (!holes_[i].is_simple(epsilon)) {
+      std::cerr << std::endl
+                << "\x1b[31m"
+                << "Hole " << i << " is not simple."
+                << "\x1b[0m" << std::endl;
       return false;
     }
-    for(unsigned i=0; i<h(); i++)
-      if( !holes_[i].is_simple(epsilon) ){
-	std::cerr << std::endl << "\x1b[31m" 
-		  << "Hole " << i << " is not simple." 
-		  <<  "\x1b[0m" << std::endl;
-	return false; 
-      }
 
-    //Check none of the Polygons' boundaries intersect w/in epsilon.
-    for(unsigned i=0; i<h(); i++)
-      if( boundary_distance(outer_boundary_, holes_[i]) <= epsilon ){
-	std::cerr << std::endl << "\x1b[31m" 
-	  << "The outer boundary intersects the boundary of hole " << i << "." 
-	  <<  "\x1b[0m" << std::endl;
-	return false; 
-      }
-    for(unsigned i=0; i<h(); i++)
-      for(unsigned j=i+1; j<h(); j++)
-	if( boundary_distance(holes_[i], holes_[j]) <= epsilon ){
-	  std::cerr << std::endl << "\x1b[31m" 
-		    << "The boundary of hole " << i 
-		    << " intersects the boundary of hole " << j << "." 
-		    <<  "\x1b[0m" << std::endl;
-	  return false;
-	}
-
-    //Check that the vertices of each hole are in the outside_boundary
-    //and not in any other holes.
-    //Loop over holes.
-    for(unsigned i=0; i<h(); i++){
-      //Loop over vertices of a hole
-      for(unsigned j=0; j<holes_[i].n(); j++){
-	if( !holes_[i][j].in(outer_boundary_, epsilon) ){
-	  std::cerr << std::endl << "\x1b[31m" 
-		    << "Vertex " << j << " of hole " << i 
-		    << " is not within the outer boundary." 
-		    <<  "\x1b[0m" << std::endl;
-	  return false; 
-	}
-	//Second loop over holes.
-	for(unsigned k=0; k<h(); k++)
-	  if( i!=k and holes_[i][j].in(holes_[k], epsilon) ){
-	    std::cerr << std::endl << "\x1b[31m" 
-		      << "Vertex " << j 
-		      << " of hole " << i 
-		      << " is in hole " << k << "." 
-		      <<  "\x1b[0m" << std::endl;
-	    return false;
-	  }
-      }
+  // Check none of the Polygons' boundaries intersect w/in epsilon.
+  for (unsigned i = 0; i < h(); i++)
+    if (boundary_distance(outer_boundary_, holes_[i]) <= epsilon) {
+      std::cerr << std::endl
+                << "\x1b[31m"
+                << "The outer boundary intersects the boundary of hole " << i
+                << "."
+                << "\x1b[0m" << std::endl;
+      return false;
     }
-
-    //Check outer_boundary is ccw and holes are cw.
-    if( outer_boundary_.area() <= 0 ){
-      std::cerr << std::endl << "\x1b[31m" 
-		<< "The outer boundary vertices are not listed ccw." 
-		<<  "\x1b[0m" << std::endl;
-      return false; 
-    }
-    for(unsigned i=0; i<h(); i++)
-      if( holes_[i].area() >= 0 ){
-	std::cerr << std::endl << "\x1b[31m" 
-		  << "The vertices of hole " << i << " are not listed cw." 
-		  <<  "\x1b[0m" << std::endl;
-	return false; 
+  for (unsigned i = 0; i < h(); i++)
+    for (unsigned j = i + 1; j < h(); j++)
+      if (boundary_distance(holes_[i], holes_[j]) <= epsilon) {
+        std::cerr << std::endl
+                  << "\x1b[31m"
+                  << "The boundary of hole " << i
+                  << " intersects the boundary of hole " << j << "."
+                  << "\x1b[0m" << std::endl;
+        return false;
       }
 
-    return true; 
-  } 
-
-
-  double Environment::boundary_length() const
-  {
-    //Precondition:  nonempty Environment.
-    assert( outer_boundary_.n() > 0 );
-
-    double length_temp = outer_boundary_.boundary_length();
-    for(unsigned i=0; i<h(); i++)
-      length_temp += holes_[i].boundary_length();
-    return length_temp;
+  // Check that the vertices of each hole are in the outside_boundary
+  // and not in any other holes.
+  // Loop over holes.
+  for (unsigned i = 0; i < h(); i++) {
+    // Loop over vertices of a hole
+    for (unsigned j = 0; j < holes_[i].n(); j++) {
+      if (!holes_[i][j].in(outer_boundary_, epsilon)) {
+        std::cerr << std::endl
+                  << "\x1b[31m"
+                  << "Vertex " << j << " of hole " << i
+                  << " is not within the outer boundary."
+                  << "\x1b[0m" << std::endl;
+        return false;
+      }
+      // Second loop over holes.
+      for (unsigned k = 0; k < h(); k++)
+        if (i != k and holes_[i][j].in(holes_[k], epsilon)) {
+          std::cerr << std::endl
+                    << "\x1b[31m"
+                    << "Vertex " << j << " of hole " << i << " is in hole " << k
+                    << "."
+                    << "\x1b[0m" << std::endl;
+          return false;
+        }
+    }
   }
 
-
-  double Environment::area() const
-  {
-    double area_temp = outer_boundary_.area();
-    for(unsigned i=0; i<h(); i++)
-      area_temp += holes_[i].area();
-    return area_temp;
+  // Check outer_boundary is ccw and holes are cw.
+  if (outer_boundary_.area() <= 0) {
+    std::cerr << std::endl
+              << "\x1b[31m"
+              << "The outer boundary vertices are not listed ccw."
+              << "\x1b[0m" << std::endl;
+    return false;
   }
-
-
-  std::vector<Point> Environment::random_points(const unsigned& count,
-						double epsilon) const
-  {
-    assert( area() > 0 );
-
-    Bounding_Box bounding_box = bbox();
-    std::vector<Point> pts_in_environment; 
-    pts_in_environment.reserve(count);
-    Point pt_temp( uniform_random_sample(bounding_box.x_min,
-					 bounding_box.x_max),
-		   uniform_random_sample(bounding_box.y_min,
-					 bounding_box.y_max) );
-    while(pts_in_environment.size() < count){
-      while(!pt_temp.in(*this, epsilon)){
-	pt_temp.set_x( uniform_random_sample(bounding_box.x_min, 
-					     bounding_box.x_max) );
-	pt_temp.set_y( uniform_random_sample(bounding_box.y_min,
-					     bounding_box.y_max) );	  
-      }
-      pts_in_environment.push_back(pt_temp);
-      pt_temp.set_x( uniform_random_sample(bounding_box.x_min, 
-					   bounding_box.x_max) );
-      pt_temp.set_y( uniform_random_sample(bounding_box.y_min,
-					   bounding_box.y_max) );
+  for (unsigned i = 0; i < h(); i++)
+    if (holes_[i].area() >= 0) {
+      std::cerr << std::endl
+                << "\x1b[31m"
+                << "The vertices of hole " << i << " are not listed cw."
+                << "\x1b[0m" << std::endl;
+      return false;
     }
-    return pts_in_environment;
+
+  return true;
+}
+
+double Environment::boundary_length() const {
+  // Precondition:  nonempty Environment.
+  assert(outer_boundary_.n() > 0);
+
+  double length_temp = outer_boundary_.boundary_length();
+  for (unsigned i = 0; i < h(); i++)
+    length_temp += holes_[i].boundary_length();
+  return length_temp;
+}
+
+double Environment::area() const {
+  double area_temp = outer_boundary_.area();
+  for (unsigned i = 0; i < h(); i++)
+    area_temp += holes_[i].area();
+  return area_temp;
+}
+
+std::vector<Point> Environment::random_points(const unsigned &count,
+                                              double epsilon) const {
+  assert(area() > 0);
+
+  Bounding_Box bounding_box = bbox();
+  std::vector<Point> pts_in_environment;
+  pts_in_environment.reserve(count);
+  Point pt_temp(uniform_random_sample(bounding_box.x_min, bounding_box.x_max),
+                uniform_random_sample(bounding_box.y_min, bounding_box.y_max));
+  while (pts_in_environment.size() < count) {
+    while (!pt_temp.in(*this, epsilon)) {
+      pt_temp.set_x(
+          uniform_random_sample(bounding_box.x_min, bounding_box.x_max));
+      pt_temp.set_y(
+          uniform_random_sample(bounding_box.y_min, bounding_box.y_max));
+    }
+    pts_in_environment.push_back(pt_temp);
+    pt_temp.set_x(
+        uniform_random_sample(bounding_box.x_min, bounding_box.x_max));
+    pt_temp.set_y(
+        uniform_random_sample(bounding_box.y_min, bounding_box.y_max));
   }
+  return pts_in_environment;
+}
 
+Polyline Environment::shortest_path(const Point &start, const Point &finish,
+                                    const Visibility_Graph &visibility_graph,
+                                    double epsilon) {
+  // true  => data printed to terminal
+  // false => silent
+  const bool PRINTING_DEBUG_DATA = false;
 
-  Polyline Environment::shortest_path(const Point& start,
-				      const Point& finish,
-				      const Visibility_Graph& visibility_graph,
-				      double epsilon)
-  {
-    //true  => data printed to terminal
-    //false => silent
-    const bool PRINTING_DEBUG_DATA = false;
+  // For now, just find one shortest path, later change this to a
+  // vector to find all shortest paths (w/in epsilon).
+  Polyline shortest_path_output;
+  Visibility_Polygon start_visibility_polygon(start, *this, epsilon);
 
-    //For now, just find one shortest path, later change this to a
-    //vector to find all shortest paths (w/in epsilon).
-    Polyline shortest_path_output;
-    Visibility_Polygon start_visibility_polygon(start, *this, epsilon);
-
-    //Trivial cases
-    if( distance(start,finish) <= epsilon ){
-      shortest_path_output.push_back(start);
-      return shortest_path_output;
-    }
-    else if( finish.in(start_visibility_polygon, epsilon) ){
-      shortest_path_output.push_back(start);
-      shortest_path_output.push_back(finish);
-      return shortest_path_output;
-    }
-
-    Visibility_Polygon finish_visibility_polygon(finish, *this, epsilon);
-
-    //Connect start and finish Points to the visibility graph
-    bool *start_visible;  //start row of visibility graph
-    bool *finish_visible; //finish row of visibility graph
-    start_visible = new bool[n()];
-    finish_visible = new bool[n()];
-    for(unsigned k=0; k<n(); k++){
-      if(  (*this)(k).in( start_visibility_polygon , epsilon )  )
-	start_visible[k] = true;
-      else
-	start_visible[k] = false;
-      if(  (*this)(k).in( finish_visibility_polygon , epsilon )  )
-	finish_visible[k] = true;
-      else
-	finish_visible[k] = false;
-    }
-
-    //Initialize search tree of visited nodes
-    std::list<Shortest_Path_Node> T;
-    //:WARNING:
-    //If T is a vector it is crucial to make T large enough that it
-    //will not be resized.  If T were resized, any iterators pointing
-    //to its contents would be invalidated, thus causing the program
-    //to fail.
-    //T.reserve( n() + 3 );
-
-    //Initialize priority queue of unexpanded nodes
-    std::set<Shortest_Path_Node> Q;
-
-    //Construct initial node
-    Shortest_Path_Node current_node;
-    //convention vertex_index == n() => corresponds to start Point
-    //vertex_index == n() + 1 => corresponds to finish Point
-    current_node.vertex_index = n();
-    current_node.cost_to_come = 0;
-    current_node.estimated_cost_to_go = distance( start , finish );
-    //Put in T and on Q
-    T.push_back( current_node );
-    T.begin()->search_tree_location = T.begin();
-    current_node.search_tree_location = T.begin();
-    T.begin()->parent_search_tree_location = T.begin();
-    current_node.parent_search_tree_location = T.begin();
-    Q.insert( current_node );
-
-    //Initialize temporary variables
-    Shortest_Path_Node child; //children of current_node
-    std::vector<Shortest_Path_Node> children;
-    //flags
-    bool solution_found = false;
-    bool child_already_visited = false;
-    //-----------Begin Main Loop-----------
-    while( !Q.empty() ){
-
-      //Pop top element off Q onto current_node
-      current_node = *Q.begin(); Q.erase( Q.begin() );
-
-      if(PRINTING_DEBUG_DATA){
-	std::cout << std::endl
-		  <<"=============="
-		  <<" current_node just poped off of Q "
-		  <<"=============="
-		  << std::endl;
-		  current_node.print();
-		  std::cout << std::endl;
-      }
-      
-      //Check for goal state
-      //(if current node corresponds to finish)
-      if( current_node.vertex_index == n() + 1 ){
-	
-	if( PRINTING_DEBUG_DATA ){
-	  std::cout <<"solution found!" 
-		    << std::endl
-		    << std::endl;
-	}
-
-	solution_found = true;
-	break;
-      }
-
-      //Expand current_node (compute children)
-      children.clear();
-
-      if( PRINTING_DEBUG_DATA ){
-	std::cout << "-------------------------------------------"
-		  << std::endl
-		  << "Expanding Current Node (Computing Children)"
-		  << std::endl
-		  << "current size of search tree T = " 
-		  << T.size()
-		  << std::endl
-		  << "-------------------------------------------"
-		  << std::endl;      
-      }
-
-      //if current_node corresponds to start
-      if( current_node.vertex_index == n() ){
-	//loop over environment vertices
-	for(unsigned i=0; i < n(); i++){
-	  if( start_visible[i] ){
-	    child.vertex_index = i;
-	    child.parent_search_tree_location 
-	      = current_node.search_tree_location;
-	    child.cost_to_come = distance( start , (*this)(i) );
-	    child.estimated_cost_to_go = distance( (*this)(i) , finish );	    
-	    children.push_back( child );
-	    
-	    if( PRINTING_DEBUG_DATA ){
-	      std::cout << std::endl << "computed child: " 
-			<< std::endl;
-	      child.print();
-	    }
-
-	  }
-	}
-      }
-      //else current_node corresponds to a vertex of the environment
-      else{
-	//check which environment vertices are visible
-	for(unsigned i=0; i < n(); i++){
-	  if( current_node.vertex_index != i )
-	    if( visibility_graph( current_node.vertex_index , i ) ){
-	      child.vertex_index = i;
-	      child.parent_search_tree_location 
-		= current_node.search_tree_location;
-	      child.cost_to_come = current_node.cost_to_come
-		+ distance( (*this)(current_node.vertex_index),
-			    (*this)(i) );
-	      child.estimated_cost_to_go = distance( (*this)(i) , finish );
-	      children.push_back( child );
-
-	      if( PRINTING_DEBUG_DATA ){
-		std::cout << std::endl << "computed child: " 
-			  << std::endl;
-		child.print();
-	      }
-	      
-	    }
-	}
-	//check if finish is visible
-	if( finish_visible[ current_node.vertex_index ] ){
-	  child.vertex_index = n() + 1;
-	  child.parent_search_tree_location 
-	    = current_node.search_tree_location;
-	  child.cost_to_come = current_node.cost_to_come
-	    + distance( (*this)(current_node.vertex_index) , finish );
-	  child.estimated_cost_to_go = 0;	    
-	  children.push_back( child );
-
-	  if( PRINTING_DEBUG_DATA ){
-	    std::cout << std::endl << "computed child: " 
-		      << std::endl;
-	    child.print();
-	  }
-
-	}
-      }
-      
-      if( PRINTING_DEBUG_DATA ){
-	std::cout << std::endl
-		  <<"-----------------------------------------"
-		  << std::endl
-		  << "Processing " << children.size() 
-		  << " children" << std::endl
-		  << "-----------------------------------------"
-		  << std::endl;      
-      }
-
-      //Process children
-      for( std::vector<Shortest_Path_Node>::iterator
-	     children_itr = children.begin();
-	   children_itr != children.end();
-	   children_itr++ ){
-	child_already_visited = false;
-
-	if( PRINTING_DEBUG_DATA ){
-	  std::cout << std::endl << "current child being processed: " 
-		    << std::endl;
-	  children_itr->print();	  
-	}
-
-	//Check if child state has already been visited 
-	//(by looking in search tree T) 
-	for( std::list<Shortest_Path_Node>::iterator T_itr = T.begin();
-	     T_itr != T.end(); T_itr++ ){
-	  if( children_itr->vertex_index 
-	      == T_itr->vertex_index ){
-	    children_itr->search_tree_location = T_itr;
-	    child_already_visited = true;
-	    break;
-	  }    
-	}	
-
-	if( !child_already_visited ){
-	  //Add child to search tree T
-	  T.push_back( *children_itr );
-	  (--T.end())->search_tree_location = --T.end();
-	  children_itr->search_tree_location = --T.end();
-	  Q.insert( *children_itr );
-	}
-	else if( children_itr->search_tree_location->cost_to_come > 
-		 children_itr->cost_to_come ){
-	  //redirect parent pointer in search tree
-	  children_itr->search_tree_location->parent_search_tree_location
-	    = children_itr->parent_search_tree_location;
-	  //and update cost data
-	  children_itr->search_tree_location->cost_to_come
-	    = children_itr->cost_to_come;
-	  //update Q
-	  for(std::set<Shortest_Path_Node>::iterator 
-		Q_itr = Q.begin();
-	      Q_itr!= Q.end();
-	      Q_itr++){
-	    if( children_itr->vertex_index == Q_itr->vertex_index ){
-	      Q.erase( Q_itr );
-	      break;
-	    }	  
-	  }
-	  Q.insert( *children_itr );	  
-	}
-
-	//If not already visited, insert into Q
-	if( !child_already_visited )
-	  Q.insert( *children_itr );
-
-	if( PRINTING_DEBUG_DATA ){
-	  std::cout << "child already visited? "
-		    << child_already_visited
-		    << std::endl;      
-	}
-      
-      }
-    }
-    //-----------End Main Loop-----------
-
-    //Recover solution
-    if( solution_found ){
-      shortest_path_output.push_back( finish );
-      std::list<Shortest_Path_Node>::iterator
-	backtrace_itr = current_node.parent_search_tree_location;
-      Point waypoint;
-
-      if( PRINTING_DEBUG_DATA ){
-	std::cout << "----------------------------" << std::endl
-		  << "backtracing to find solution" << std::endl
-		  << "----------------------------" << std::endl;
-
-      }
-
-      while( true ){
-
-	if( PRINTING_DEBUG_DATA ){
-	  std::cout << "backtrace node is "
-		    << std::endl;
-	  backtrace_itr->print();
-	  std::cout << std::endl;      
-	}
-
-	if( backtrace_itr->vertex_index < n() )
-	  waypoint = (*this)( backtrace_itr->vertex_index );
-	else if( backtrace_itr->vertex_index == n() )
-	  waypoint = start;
-	//Add vertex if not redundant
-	if( shortest_path_output.size() > 0
-	    and distance( shortest_path_output[ shortest_path_output.size()
-						- 1 ],
-			  waypoint ) > epsilon )
-	  shortest_path_output.push_back( waypoint );
-	if( backtrace_itr->cost_to_come == 0 )
-	  break;
-	backtrace_itr = backtrace_itr->parent_search_tree_location;
-      }
-      shortest_path_output.reverse();
-    }
-
-    //free memory
-    delete [] start_visible;
-    delete [] finish_visible;
-
-    //shortest_path_output.eliminate_redundant_vertices( epsilon );
-    //May not be desirable to eliminate redundant vertices, because
-    //those redundant vertices can make successive waypoints along the
-    //shortest path robustly visible (and thus easier for a robot to
-    //navigate)
-
+  // Trivial cases
+  if (distance(start, finish) <= epsilon) {
+    shortest_path_output.push_back(start);
+    return shortest_path_output;
+  } else if (finish.in(start_visibility_polygon, epsilon)) {
+    shortest_path_output.push_back(start);
+    shortest_path_output.push_back(finish);
     return shortest_path_output;
   }
-  Polyline Environment::shortest_path(const Point& start,
-				      const Point& finish,
-				      double epsilon)
-  {
-    return shortest_path( start,
-			  finish,
-			  Visibility_Graph(*this, epsilon),
-			  epsilon );
+
+  Visibility_Polygon finish_visibility_polygon(finish, *this, epsilon);
+
+  // Connect start and finish Points to the visibility graph
+  bool *start_visible;  // start row of visibility graph
+  bool *finish_visible; // finish row of visibility graph
+  start_visible = new bool[n()];
+  finish_visible = new bool[n()];
+  for (unsigned k = 0; k < n(); k++) {
+    if ((*this)(k).in(start_visibility_polygon, epsilon))
+      start_visible[k] = true;
+    else
+      start_visible[k] = false;
+    if ((*this)(k).in(finish_visibility_polygon, epsilon))
+      finish_visible[k] = true;
+    else
+      finish_visible[k] = false;
   }
 
+  // Initialize search tree of visited nodes
+  std::list<Shortest_Path_Node> T;
+  //:WARNING:
+  // If T is a vector it is crucial to make T large enough that it
+  // will not be resized.  If T were resized, any iterators pointing
+  // to its contents would be invalidated, thus causing the program
+  // to fail.
+  // T.reserve( n() + 3 );
 
-  void Environment::write_to_file(const std::string& filename,
-				  int fios_precision_temp)
-  {
-    assert( fios_precision_temp >= 1 );
+  // Initialize priority queue of unexpanded nodes
+  std::set<Shortest_Path_Node> Q;
 
-    std::ofstream fout( filename.c_str() );
-    //fout.open( filename.c_str() );  //Alternatives.
-    //fout << *this;
-    fout.setf(std::ios::fixed);
-    fout.setf(std::ios::showpoint);
-    fout.precision(fios_precision_temp);
-    fout << "//Environment Model" << std::endl;
-    fout << "//Outer Boundary" << std::endl << outer_boundary_; 
-    for(unsigned i=0; i<h(); i++)
-      {
-	fout << "//Hole" << std::endl << holes_[i];
+  // Construct initial node
+  Shortest_Path_Node current_node;
+  // convention vertex_index == n() => corresponds to start Point
+  // vertex_index == n() + 1 => corresponds to finish Point
+  current_node.vertex_index = n();
+  current_node.cost_to_come = 0;
+  current_node.estimated_cost_to_go = distance(start, finish);
+  // Put in T and on Q
+  T.push_back(current_node);
+  T.begin()->search_tree_location = T.begin();
+  current_node.search_tree_location = T.begin();
+  T.begin()->parent_search_tree_location = T.begin();
+  current_node.parent_search_tree_location = T.begin();
+  Q.insert(current_node);
+
+  // Initialize temporary variables
+  Shortest_Path_Node child; // children of current_node
+  std::vector<Shortest_Path_Node> children;
+  // flags
+  bool solution_found = false;
+  bool child_already_visited = false;
+  //-----------Begin Main Loop-----------
+  while (!Q.empty()) {
+
+    // Pop top element off Q onto current_node
+    current_node = *Q.begin();
+    Q.erase(Q.begin());
+
+    if (PRINTING_DEBUG_DATA) {
+      std::cout << std::endl
+                << "=============="
+                << " current_node just poped off of Q "
+                << "==============" << std::endl;
+      current_node.print();
+      std::cout << std::endl;
+    }
+
+    // Check for goal state
+    //(if current node corresponds to finish)
+    if (current_node.vertex_index == n() + 1) {
+
+      if (PRINTING_DEBUG_DATA) {
+        std::cout << "solution found!" << std::endl << std::endl;
       }
-    //fout << "//EOF marker";
-    fout.close();
-  }
 
+      solution_found = true;
+      break;
+    }
 
-  Point& Environment::operator () (unsigned k)
-  {
-    //std::pair<unsigned,unsigned> ij( one_to_two(k) );
-    std::pair<unsigned,unsigned> ij( flattened_index_key_[k] );
-    return (*this)[ ij.first ][ ij.second ];
-  }
+    // Expand current_node (compute children)
+    children.clear();
 
+    if (PRINTING_DEBUG_DATA) {
+      std::cout << "-------------------------------------------" << std::endl
+                << "Expanding Current Node (Computing Children)" << std::endl
+                << "current size of search tree T = " << T.size() << std::endl
+                << "-------------------------------------------" << std::endl;
+    }
 
-  void Environment::enforce_standard_form()
-  {
-    if( outer_boundary_.area() < 0 )
-      outer_boundary_.reverse();
-    outer_boundary_.enforce_standard_form();
-    for(unsigned i=0; i<h(); i++){
-      if( holes_[i].area() > 0 )
-	holes_[i].reverse();
-      holes_[i].enforce_standard_form();
+    // if current_node corresponds to start
+    if (current_node.vertex_index == n()) {
+      // loop over environment vertices
+      for (unsigned i = 0; i < n(); i++) {
+        if (start_visible[i]) {
+          child.vertex_index = i;
+          child.parent_search_tree_location = current_node.search_tree_location;
+          child.cost_to_come = distance(start, (*this)(i));
+          child.estimated_cost_to_go = distance((*this)(i), finish);
+          children.push_back(child);
+
+          if (PRINTING_DEBUG_DATA) {
+            std::cout << std::endl << "computed child: " << std::endl;
+            child.print();
+          }
+        }
+      }
+    }
+    // else current_node corresponds to a vertex of the environment
+    else {
+      // check which environment vertices are visible
+      for (unsigned i = 0; i < n(); i++) {
+        if (current_node.vertex_index != i)
+          if (visibility_graph(current_node.vertex_index, i)) {
+            child.vertex_index = i;
+            child.parent_search_tree_location =
+                current_node.search_tree_location;
+            child.cost_to_come =
+                current_node.cost_to_come +
+                distance((*this)(current_node.vertex_index), (*this)(i));
+            child.estimated_cost_to_go = distance((*this)(i), finish);
+            children.push_back(child);
+
+            if (PRINTING_DEBUG_DATA) {
+              std::cout << std::endl << "computed child: " << std::endl;
+              child.print();
+            }
+          }
+      }
+      // check if finish is visible
+      if (finish_visible[current_node.vertex_index]) {
+        child.vertex_index = n() + 1;
+        child.parent_search_tree_location = current_node.search_tree_location;
+        child.cost_to_come =
+            current_node.cost_to_come +
+            distance((*this)(current_node.vertex_index), finish);
+        child.estimated_cost_to_go = 0;
+        children.push_back(child);
+
+        if (PRINTING_DEBUG_DATA) {
+          std::cout << std::endl << "computed child: " << std::endl;
+          child.print();
+        }
+      }
+    }
+
+    if (PRINTING_DEBUG_DATA) {
+      std::cout << std::endl
+                << "-----------------------------------------" << std::endl
+                << "Processing " << children.size() << " children" << std::endl
+                << "-----------------------------------------" << std::endl;
+    }
+
+    // Process children
+    for (std::vector<Shortest_Path_Node>::iterator children_itr =
+             children.begin();
+         children_itr != children.end(); children_itr++) {
+      child_already_visited = false;
+
+      if (PRINTING_DEBUG_DATA) {
+        std::cout << std::endl
+                  << "current child being processed: " << std::endl;
+        children_itr->print();
+      }
+
+      // Check if child state has already been visited
+      //(by looking in search tree T)
+      for (std::list<Shortest_Path_Node>::iterator T_itr = T.begin();
+           T_itr != T.end(); T_itr++) {
+        if (children_itr->vertex_index == T_itr->vertex_index) {
+          children_itr->search_tree_location = T_itr;
+          child_already_visited = true;
+          break;
+        }
+      }
+
+      if (!child_already_visited) {
+        // Add child to search tree T
+        T.push_back(*children_itr);
+        (--T.end())->search_tree_location = --T.end();
+        children_itr->search_tree_location = --T.end();
+        Q.insert(*children_itr);
+      } else if (children_itr->search_tree_location->cost_to_come >
+                 children_itr->cost_to_come) {
+        // redirect parent pointer in search tree
+        children_itr->search_tree_location->parent_search_tree_location =
+            children_itr->parent_search_tree_location;
+        // and update cost data
+        children_itr->search_tree_location->cost_to_come =
+            children_itr->cost_to_come;
+        // update Q
+        for (std::set<Shortest_Path_Node>::iterator Q_itr = Q.begin();
+             Q_itr != Q.end(); Q_itr++) {
+          if (children_itr->vertex_index == Q_itr->vertex_index) {
+            Q.erase(Q_itr);
+            break;
+          }
+        }
+        Q.insert(*children_itr);
+      }
+
+      // If not already visited, insert into Q
+      if (!child_already_visited)
+        Q.insert(*children_itr);
+
+      if (PRINTING_DEBUG_DATA) {
+        std::cout << "child already visited? " << child_already_visited
+                  << std::endl;
+      }
     }
   }
+  //-----------End Main Loop-----------
 
+  // Recover solution
+  if (solution_found) {
+    shortest_path_output.push_back(finish);
+    std::list<Shortest_Path_Node>::iterator backtrace_itr =
+        current_node.parent_search_tree_location;
+    Point waypoint;
 
-  void Environment::eliminate_redundant_vertices(double epsilon)
-  {
-    outer_boundary_.eliminate_redundant_vertices(epsilon);
-    for(unsigned i=0; i<holes_.size(); i++)
-      holes_[i].eliminate_redundant_vertices(epsilon);
+    if (PRINTING_DEBUG_DATA) {
+      std::cout << "----------------------------" << std::endl
+                << "backtracing to find solution" << std::endl
+                << "----------------------------" << std::endl;
+    }
 
-    update_flattened_index_key();
+    while (true) {
+
+      if (PRINTING_DEBUG_DATA) {
+        std::cout << "backtrace node is " << std::endl;
+        backtrace_itr->print();
+        std::cout << std::endl;
+      }
+
+      if (backtrace_itr->vertex_index < n())
+        waypoint = (*this)(backtrace_itr->vertex_index);
+      else if (backtrace_itr->vertex_index == n())
+        waypoint = start;
+      // Add vertex if not redundant
+      if (shortest_path_output.size() > 0 and
+          distance(shortest_path_output[shortest_path_output.size() - 1],
+                   waypoint) > epsilon)
+        shortest_path_output.push_back(waypoint);
+      if (backtrace_itr->cost_to_come == 0)
+        break;
+      backtrace_itr = backtrace_itr->parent_search_tree_location;
+    }
+    shortest_path_output.reverse();
   }
 
+  // free memory
+  delete[] start_visible;
+  delete[] finish_visible;
 
-  void Environment::reverse_holes()
-  {
-    for(unsigned i=0; i < holes_.size(); i++)
+  // shortest_path_output.eliminate_redundant_vertices( epsilon );
+  // May not be desirable to eliminate redundant vertices, because
+  // those redundant vertices can make successive waypoints along the
+  // shortest path robustly visible (and thus easier for a robot to
+  // navigate)
+
+  return shortest_path_output;
+}
+Polyline Environment::shortest_path(const Point &start, const Point &finish,
+                                    double epsilon) {
+  return shortest_path(start, finish, Visibility_Graph(*this, epsilon),
+                       epsilon);
+}
+
+void Environment::write_to_file(const std::string &filename,
+                                int fios_precision_temp) {
+  assert(fios_precision_temp >= 1);
+
+  std::ofstream fout(filename.c_str());
+  // fout.open( filename.c_str() );  //Alternatives.
+  // fout << *this;
+  fout.setf(std::ios::fixed);
+  fout.setf(std::ios::showpoint);
+  fout.precision(fios_precision_temp);
+  fout << "//Environment Model" << std::endl;
+  fout << "//Outer Boundary" << std::endl << outer_boundary_;
+  for (unsigned i = 0; i < h(); i++) {
+    fout << "//Hole" << std::endl << holes_[i];
+  }
+  // fout << "//EOF marker";
+  fout.close();
+}
+
+Point &Environment::operator()(unsigned k) {
+  // std::pair<unsigned,unsigned> ij( one_to_two(k) );
+  std::pair<unsigned, unsigned> ij(flattened_index_key_[k]);
+  return (*this)[ij.first][ij.second];
+}
+
+void Environment::enforce_standard_form() {
+  if (outer_boundary_.area() < 0)
+    outer_boundary_.reverse();
+  outer_boundary_.enforce_standard_form();
+  for (unsigned i = 0; i < h(); i++) {
+    if (holes_[i].area() > 0)
       holes_[i].reverse();
+    holes_[i].enforce_standard_form();
   }
+}
 
+void Environment::eliminate_redundant_vertices(double epsilon) {
+  outer_boundary_.eliminate_redundant_vertices(epsilon);
+  for (unsigned i = 0; i < holes_.size(); i++)
+    holes_[i].eliminate_redundant_vertices(epsilon);
 
-  void Environment::update_flattened_index_key()
-  {
-    flattened_index_key_.clear();
-    std::pair<unsigned, unsigned> pair_temp;
-    for(unsigned i=0; i<=h(); i++){
-    for(unsigned j=0; j<(*this)[i].n(); j++){
+  update_flattened_index_key();
+}
+
+void Environment::reverse_holes() {
+  for (unsigned i = 0; i < holes_.size(); i++)
+    holes_[i].reverse();
+}
+
+void Environment::update_flattened_index_key() {
+  flattened_index_key_.clear();
+  std::pair<unsigned, unsigned> pair_temp;
+  for (unsigned i = 0; i <= h(); i++) {
+    for (unsigned j = 0; j < (*this)[i].n(); j++) {
       pair_temp.first = i;
       pair_temp.second = j;
-      flattened_index_key_.push_back( pair_temp );
-    }}
-  }
-
-
-  std::pair<unsigned,unsigned> Environment::one_to_two(unsigned k) const
-  {
-    std::pair<unsigned,unsigned> two(0,0);
-    //Strategy: add up vertex count of each Polygon (outer boundary +
-    //holes) until greater than k
-    unsigned current_polygon_index = 0;
-    unsigned vertex_count_up_to_current_polygon = (*this)[0].n();
-    unsigned vertex_count_up_to_last_polygon = 0;
-
-    while( k >= vertex_count_up_to_current_polygon
-	   and current_polygon_index < (*this).h() ){
-      current_polygon_index++;
-      two.first = two.first + 1;
-      vertex_count_up_to_last_polygon = vertex_count_up_to_current_polygon;
-      vertex_count_up_to_current_polygon += (*this)[current_polygon_index].n();
-    }
-    two.second = k - vertex_count_up_to_last_polygon;
-    
-    return two;
-  }
-
-
-  std::ostream& operator << (std::ostream& outs, 
-			     const Environment& environment_temp)
-  {
-    outs << "//Environment Model" << std::endl;
-    outs << "//Outer Boundary" << std::endl << environment_temp[0]; 
-    for(unsigned i=1; i<=environment_temp.h(); i++){
-      outs << "//Hole" << std::endl << environment_temp[i];
-    }
-    //outs << "//EOF marker";
-    return outs;
-  }
-  
-
-  //Guards
-
-
-  Guards::Guards(const std::string& filename)
-  {
-    std::ifstream fin(filename.c_str());
-    //if(fin.fail()) { std::cerr << "\x1b[5;31m" << "Input file
-    //opening failed." << "\x1b[0m\n" << "\a \n"; exit(1);}
-    assert( !fin.fail() );
-
-    //Temp vars for numbers to be read from file.
-    double x_temp, y_temp;  
-    
-    //Skip comments
-    while( fin.peek() == '/' ) 
-      fin.ignore(200,'\n');
-
-    //Read positions.
-    while (1){
-      fin >> x_temp >> y_temp;
-      if( fin.eof() )
-	{ fin.close(); return; }
-      positions_.push_back( Point(x_temp, y_temp) );
-      //Skip to next line.
-      fin.ignore(1);
-      //Skip comments
-      while( fin.peek() == '/' )
-	fin.ignore(200,'\n');
+      flattened_index_key_.push_back(pair_temp);
     }
   }
-
-
-  bool Guards::are_lex_ordered() const
-  {
-    //if more than one guard.
-    if(positions_.size() > 1)
-      for(unsigned i=0; i<positions_.size()-1; i++)
-	if(positions_[i] > positions_[i+1])
-	  return false;
-    return true;
-  }
-
-
-  bool Guards::noncolocated(double epsilon) const
-  {
-    for(unsigned i=0; i<positions_.size(); i++)
-      for(unsigned j=i+1; j<positions_.size(); j++)
-	if( distance(positions_[i], positions_[j]) <= epsilon )
-	  return false;
-    return true;
-  }
-
-
-  bool Guards::in(const Polygon& polygon_temp, double epsilon) const
-  {
-    for(unsigned i=0; i<positions_.size(); i++)
-      if(!positions_[i].in(polygon_temp, epsilon))
-	return false;
-    return true;
-  }
-
-
-  bool Guards::in(const Environment& environment_temp, double epsilon) const
-  {
-    for(unsigned i=0; i<positions_.size(); i++)
-      if(!positions_[i].in(environment_temp, epsilon))
-	return false;
-    return true;
-  }
-
-
-  double Guards::diameter() const
-  {
-    //Precondition:  more than 0 guards
-    assert( N() > 0 );
-
-    double running_max=0;
-    for(unsigned i=0; i<N()-1; i++){
-    for(unsigned j=i+1; j<N(); j++){
-      if( distance( (*this)[i] , (*this)[j] ) > running_max )
-	running_max = distance( (*this)[i] , (*this)[j] );
-    }}
-    return running_max;
-  }
-
-
-  Bounding_Box Guards::bbox() const
-  {
-    //Precondition:  nonempty Guard set
-    assert( positions_.size() > 0 );
-
-    Bounding_Box bounding_box;
-    double x_min=positions_[0].x(), x_max=positions_[0].x(),
-      y_min=positions_[0].y(), y_max=positions_[0].y();
-    for(unsigned i = 1; i <  positions_.size(); i++){
-      if(x_min > positions_[i].x())  { x_min=positions_[i].x(); }
-      if(x_max < positions_[i].x())  { x_max=positions_[i].x(); }
-      if(y_min > positions_[i].y())  { y_min=positions_[i].y(); }
-      if(y_max < positions_[i].y())  { y_max=positions_[i].y(); }
-    }
-    bounding_box.x_min=x_min; bounding_box.x_max=x_max;
-    bounding_box.y_min=y_min; bounding_box.y_max=y_max;
-    return bounding_box;
-  }
-
-
-  void Guards::write_to_file(const std::string& filename,
-			     int fios_precision_temp)
-  {
-    assert( fios_precision_temp >= 1 );
-
-    std::ofstream fout( filename.c_str() );
-    //fout.open( filename.c_str() );  //Alternatives.
-    //fout << *this;
-    fout.setf(std::ios::fixed);
-    fout.setf(std::ios::showpoint);
-    fout.precision(fios_precision_temp);
-    fout << "//Guard Positions" << std::endl; 
-    for(unsigned i=0; i<positions_.size(); i++)
-      fout << positions_[i].x() << "  " << positions_[i].y() << std::endl;
-    //fout << "//EOF marker";
-    fout.close();
-  }
-
-
-  void Guards::enforce_lex_order()
-  {
-    //std::stable_sort(positions_.begin(), positions_.end());
-    std::sort(positions_.begin(), positions_.end());
-  }
-
-
-  void Guards::reverse()
-  {
-    std::reverse( positions_.begin() , positions_.end() );
-  }
-
-
-  void Guards::snap_to_vertices_of(const Environment& environment_temp,
-				   double epsilon)
-  {
-    for(unsigned i=0; i<positions_.size(); i++)
-      positions_[i].snap_to_vertices_of(environment_temp);
-  }
-
-
-  void Guards::snap_to_vertices_of(const Polygon& polygon_temp,
-				   double epsilon)
-  {
-    for(unsigned i=0; i<positions_.size(); i++)
-      positions_[i].snap_to_vertices_of(polygon_temp);
-  }
-
-
-  void Guards::snap_to_boundary_of(const Environment& environment_temp,
-				   double epsilon)
-  {
-    for(unsigned i=0; i<positions_.size(); i++)
-      positions_[i].snap_to_boundary_of(environment_temp);
-  }
-
-
-  void Guards::snap_to_boundary_of(const Polygon& polygon_temp,
-				   double epsilon)
-  {
-    for(unsigned i=0; i<positions_.size(); i++)
-      positions_[i].snap_to_boundary_of(polygon_temp);
-  }
-
-
-  std::ostream& operator << (std::ostream& outs, const Guards& guards)
-  {
-    outs << "//Guard Positions" << std::endl; 
-    for(unsigned i=0; i<guards.N(); i++)
-      outs << guards[i].x() << "  " << guards[i].y() << std::endl;
-    //outs << "//EOF marker";
-    return outs;
-  }
-
-
-  //Visibility_Polygon
-
-
-  bool Visibility_Polygon::is_spike( const Point& observer,
-				     const Point& point1,
-				     const Point& point2,
-				     const Point& point3, 
-				     double epsilon) const
-  {
-
-    return(  
-         //Make sure observer not colocated with any of the points.
-	   distance( observer , point1 ) > epsilon
-	   and distance( observer , point2 ) > epsilon
-	   and distance( observer , point3 ) > epsilon
-	 //Test whether there is a spike with point2 as the tip
-	   and (  ( distance(observer,point2) 
-		    >= distance(observer,point1)
-		    and distance(observer,point2) 
-		    >= distance(observer,point3) ) 
-		  or ( distance(observer,point2) 
-		       <= distance(observer,point1)
-		       and distance(observer,point2) 
-		       <= distance(observer,point3) )  )
-	 //and the pike is sufficiently sharp,
-	   and std::max(  distance( Ray(observer, point1), point2 ), 
-			  distance( Ray(observer, point3), point2 )  )
-	   <= epsilon  
-	     );
-    //Formerly used
-    //std::fabs( Polygon(point1, point2, point3).area() ) < epsilon
-  }
-
-  
-  void Visibility_Polygon::chop_spikes_at_back(const Point& observer,
-					       double epsilon)
-  {
-    //Eliminate "special case" vertices of the visibility polygon.
-    //While the top three vertices form a spike.
-    while(  vertices_.size() >= 3
-	    and is_spike( observer, 
-			  vertices_[vertices_.size()-3],
-			  vertices_[vertices_.size()-2],
-			  vertices_[vertices_.size()-1], epsilon )  ){
-      vertices_[vertices_.size()-2] = vertices_[vertices_.size()-1];
-      vertices_.pop_back();
-    }
-  }
-
-
-  void Visibility_Polygon::chop_spikes_at_wrap_around(const Point& observer,
-						      double epsilon)
-  {
-    //Eliminate "special case" vertices of the visibility polygon at
-    //wrap-around.  While the there's a spike at the wrap-around,
-    while(  vertices_.size() >= 3 
-	    and is_spike( observer,
-			  vertices_[vertices_.size()-2],
-			  vertices_[vertices_.size()-1],
-			  vertices_[0], epsilon )  ){
-      //Chop off the tip of the spike.
-      vertices_.pop_back();
-    }
-  }
-
-
-  void Visibility_Polygon::chop_spikes(const Point& observer,
-				       double epsilon)
-  {    
-    std::set<Point> spike_tips;
-    std::vector<Point> vertices_temp;
-    //Middle point is potentially the tip of a spike
-    for(unsigned i=0; i<vertices_.size(); i++)
-      if(   distance(  (*this)[i+2], 
-		       Line_Segment( (*this)[i], (*this)[i+1] )  )
-	    <= epsilon
-	    or
-	    distance(  (*this)[i], 
-		       Line_Segment( (*this)[i+1], (*this)[i+2] )  )
-	    <= epsilon   )
-	spike_tips.insert( (*this)[i+1] );
-    
-    for(unsigned i=0; i<vertices_.size(); i++)
-      if( spike_tips.find(vertices_[i]) == spike_tips.end() )
-	vertices_temp.push_back( vertices_[i] );
-    vertices_.swap( vertices_temp );
-  }
-
-
-  void Visibility_Polygon::
-  print_cv_and_ae(const Polar_Point_With_Edge_Info& current_vertex,
-		  const std::list<Polar_Edge>::iterator&
-		  active_edge)
-  {
-    std::cout << "           current_vertex [x  y  bearing  range is_first] = ["
-	      << current_vertex.x() << "  "
-	      << current_vertex.y() << "  "
-	      << current_vertex.bearing() << "  "
-	      << current_vertex.range() << "  "
-	      << current_vertex.is_first << "]" << std::endl;
-    std::cout << "1st point of current_vertex's edge [x  y  bearing  range] = ["
-	      << (current_vertex.incident_edge->first).x() << "  " 
-	      << (current_vertex.incident_edge->first).y() << "  "
-	      << (current_vertex.incident_edge->first).bearing() << "  "
-	      << (current_vertex.incident_edge->first).range() << "]" 
-	      << std::endl;
-    std::cout << "2nd point of current_vertex's edge [x  y  bearing  range] = [" 
-	      << (current_vertex.incident_edge->second).x() << "  " 
-	      << (current_vertex.incident_edge->second).y() << "  "
-	      << (current_vertex.incident_edge->second).bearing() << "  "
-	      << (current_vertex.incident_edge->second).range() << "]" 
-	      << std::endl;
-    std::cout << "          1st point of active_edge [x  y  bearing  range] = ["
-	      << (active_edge->first).x() << "  " 
-	      << (active_edge->first).y() << "  "
-	      << (active_edge->first).bearing() << "  "
-	      << (active_edge->first).range() << "]" << std::endl;
-    std::cout << "          2nd point of active_edge [x  y  bearing  range] = [" 
-	      << (active_edge->second).x() << "  " 
-	      << (active_edge->second).y() << "  "
-	      << (active_edge->second).bearing() << "  "
-	      << (active_edge->second).range() << "]" << std::endl;
-  }
-
-
-  Visibility_Polygon::Visibility_Polygon(const Point& observer,
-					 const Environment& environment_temp,
-					 double epsilon)
-    : observer_(observer)
-  {
-    //Visibility polygon algorithm for environments with holes 
-    //Radial line (AKA angular plane) sweep technique.
-    //
-    //Based on algorithms described in 
-    //
-    //[1] "Automated Camera Layout to Satisfy Task-Specific and
-    //Floorplan-Specific Coverage Requirements" by Ugur Murat Erdem
-    //and Stan Scarloff, April 15, 2004
-    //available at BUCS Technical Report Archive:
-    //http://www.cs.bu.edu/techreports/pdf/2004-015-camera-layout.pdf
-    //
-    //[2] "Art Gallery Theorems and Algorithms" by Joseph O'Rourke
-    //
-    //[3] "Visibility Algorithms in the Plane" by Ghosh
-    //
-
-    //We define a k-point is a point seen on the other side of a
-    //visibility occluding corner.  This name is appropriate because
-    //the vertical line in the letter "k" is like a line-of-sight past
-    //the corner of the "k".
-
-    //
-    //Preconditions:
-    //(1)  the Environment is epsilon-valid,
-    //(2)  the Point observer is actually in the Environment
-    //     environment_temp,
-    //(3)  the guard has been epsilon-snapped to the boundary, followed
-    //     by vertices of the environment (the order of the snapping
-    //     is important).
-    //
-    //:WARNING: 
-    //For efficiency, the assertions corresponding to these
-    //preconditions have been excluded.
-    //
-    //assert( environment_temp.is_valid(epsilon) );
-    //assert( environment_temp.is_in_standard_form() );
-    //assert( observer.in(environment_temp, epsilon) );
-
-    //true  => data printed to terminal
-    //false => silent
-    const bool PRINTING_DEBUG_DATA = false;
-
-    //The visibility polygon cannot have more vertices than the environment.
-    vertices_.reserve( environment_temp.n() );
-
-    //
-    //--------PREPROCESSING--------
-    //
-     
-    //Construct a POLAR EDGE LIST from environment_temp's outer
-    //boundary and holes.  During this construction, those edges are
-    //split which either (1) cross the ray emanating from the observer
-    //parallel to the x-axis (of world coords), or (2) contain the
-    //observer in their relative interior (w/in epsilon).  Also, edges
-    //having first vertex bearing >= second vertex bearing are
-    //eliminated because they cannot possibly contribute to the
-    //visibility polygon.
-    std::list<Polar_Edge> elp;
-    Polar_Point ppoint1, ppoint2;
-    Polar_Point split_bottom, split_top;
-    double t;
-    //If the observer is standing on the Enviroment boundary with its
-    //back to the wall, these will be the bearings of the next vertex
-    //to the right and to the left, respectively.
-    Angle right_wall_bearing;
-    Angle left_wall_bearing;
-    for(unsigned i=0; i<=environment_temp.h(); i++){
-    for(unsigned j=0; j<environment_temp[i].n(); j++){      
-      ppoint1 = Polar_Point( observer, environment_temp[i][j] );
-      ppoint2 = Polar_Point( observer, environment_temp[i][j+1] );
-
-      //If the observer is in the relative interior of the edge.
-      if(  observer.in_relative_interior_of( Line_Segment(ppoint1, ppoint2),
-					     epsilon )  ){
-	//Split the edge at the observer and add the resulting two
-	//edges to elp (the polar edge list).
-	split_bottom = Polar_Point(observer, observer);
-	split_top = Polar_Point(observer, observer);
-
-	if( ppoint2.bearing() == Angle(0.0) )
-	  ppoint2.set_bearing_to_2pi();
-	
-	left_wall_bearing = ppoint1.bearing();
-	right_wall_bearing = ppoint2.bearing();
-
-	elp.push_back(  Polar_Edge( ppoint1   , split_bottom )  );
-	elp.push_back(  Polar_Edge( split_top , ppoint2      )  );
-	continue;
-      }
-
-      //Else if the observer is on first vertex of edge.
-      else if( distance(observer, ppoint1) <= epsilon ){
-	if( ppoint2.bearing() == Angle(0.0) )
-	  ppoint2.set_bearing_to_2pi();
-	//Get right wall bearing.
-	right_wall_bearing = ppoint2.bearing();
-	elp.push_back(  Polar_Edge( Polar_Point(observer, observer),
-				    ppoint2 )  );
-	continue;
-      }
-      //Else if the observer is on second vertex of edge.
-      else if( distance(observer, ppoint2) <= epsilon ){
-	//Get left wall bearing.
-	left_wall_bearing = ppoint1.bearing();
-	elp.push_back(  Polar_Edge( ppoint1,
-				    Polar_Point(observer, observer) )  );	
-	continue;
-      }
-
-      //Otherwise the observer is not on the edge.
-
-      //If edge not horizontal (w/in epsilon).
-      else if(  std::fabs( ppoint1.y() - ppoint2.y() ) > epsilon  ){
-	//Possible source of numerical instability?
-	t = ( observer.y() - ppoint2.y() ) 
-	  / ( ppoint1.y() - ppoint2.y() );
-	//If edge crosses the ray emanating horizontal and right of
-	//the observer.
-	if( 0 < t and t < 1 and 
-	    observer.x() < t*ppoint1.x() + (1-t)*ppoint2.x() ){ 
-	  //If first point is above, omit edge because it runs
-	  //'against the grain'.
-	  if( ppoint1.y() > observer.y() )
-	    continue;
-	  //Otherwise split the edge, making sure angles are assigned
-	  //correctly on each side of the split point.
-	  split_bottom = split_top 
-	    = Polar_Point(  observer,
-			    Point( t*ppoint1.x() + (1-t)*ppoint2.x(),
-				   observer.y() )  );
-	  split_top.set_bearing( Angle(0.0) );
-	  split_bottom.set_bearing_to_2pi();
-	  elp.push_back(  Polar_Edge( ppoint1   , split_bottom )  );
-	  elp.push_back(  Polar_Edge( split_top , ppoint2      )  );
-	  continue;
-	}
-	//If the edge is not horizontal and doesn't cross the ray
-	//emanating horizontal and right of the observer.
-	else if( ppoint1.bearing() >= ppoint2.bearing()
-		 and ppoint2.bearing() == Angle(0.0) 
-		 and ppoint1.bearing() > Angle(M_PI) )
-	  ppoint2.set_bearing_to_2pi();
-	//Filter out edges which run 'against the grain'.
-	else if(  ( ppoint1.bearing() == Angle(0,0)
-		    and ppoint2.bearing() > Angle(M_PI) )
-		  or  ppoint1.bearing() >= ppoint2.bearing()  )
-	  continue;
-	elp.push_back(  Polar_Edge( ppoint1, ppoint2 )  );
-	continue;
-      }    
-      //If edge is horizontal (w/in epsilon).
-      else{
-	//Filter out edges which run 'against the grain'.
-	if( ppoint1.bearing() >= ppoint2.bearing() ) 
-	  continue;
-	elp.push_back(  Polar_Edge( ppoint1, ppoint2 )  );
-      }
-    }}
-  
-    //Construct a SORTED LIST, q1, OF VERTICES represented by
-    //Polar_Point_With_Edge_Info objects.  A
-    //Polar_Point_With_Edge_Info is a derived class of Polar_Point
-    //which includes (1) a pointer to the corresponding edge
-    //(represented as a Polar_Edge) in the polar edge list elp, and
-    //(2) a boolean (is_first) which is true iff that vertex is the
-    //first Point of the respective edge (is_first == false => it's
-    //second Point).  q1 is sorted according to lex. order of polar
-    //coordinates just as Polar_Points are, but with the additional
-    //requirement that if two vertices have equal polar coordinates,
-    //the vertex which is the first point of its respective edge is
-    //considered greater.  q1 will serve as an event point queue for
-    //the radial sweep.
-    std::list<Polar_Point_With_Edge_Info> q1;
-    Polar_Point_With_Edge_Info ppoint_wei1, ppoint_wei2;
-    std::list<Polar_Edge>::iterator elp_iterator;
-    for(elp_iterator=elp.begin(); 
-	elp_iterator!=elp.end(); 
-	elp_iterator++){
-      ppoint_wei1.set_polar_point( elp_iterator->first );
-      ppoint_wei1.incident_edge = elp_iterator;
-      ppoint_wei1.is_first = true;
-      ppoint_wei2.set_polar_point( elp_iterator->second );
-      ppoint_wei2.incident_edge = elp_iterator;
-      ppoint_wei2.is_first = false;
-      //If edge contains the observer, then adjust the bearing of
-      //the Polar_Point containing the observer.
-      if( distance(observer, ppoint_wei1) <= epsilon ){
-	if( right_wall_bearing > left_wall_bearing ){
-	  ppoint_wei1.set_bearing( right_wall_bearing );
-	  (elp_iterator->first).set_bearing( right_wall_bearing );
-	}
-	else{
-	  ppoint_wei1.set_bearing( Angle(0.0) );
-	  (elp_iterator->first).set_bearing( Angle(0.0) );
-	}
-      } 
-      else if( distance(observer, ppoint_wei2) <= epsilon ){
-	if( right_wall_bearing > left_wall_bearing ){
-	  ppoint_wei2.set_bearing(right_wall_bearing);
-	  (elp_iterator->second).set_bearing( right_wall_bearing );
-	}
-	else{
-	  ppoint_wei2.set_bearing_to_2pi();
-	  (elp_iterator->second).set_bearing_to_2pi();
-	}
-      }
-      q1.push_back(ppoint_wei1);
-      q1.push_back(ppoint_wei2);
-    }
-    //Put event point in correct order.
-    //STL list's sort method is a stable sort. 
-    q1.sort();
-
-    if(PRINTING_DEBUG_DATA){
-      std::cout << std::endl 
-		<< "\E[1;37;40m" 
-		<< "COMPUTING VISIBILITY POLYGON " << std::endl
-		<<  "for an observer located at [x y] = [" 
-		<< observer << "]" 
-		<< "\x1b[0m" 
-		<< std::endl << std::endl
-		<< "\E[1;37;40m" <<"PREPROCESSING" << "\x1b[0m" 
-		<< std::endl << std::endl 
-		<< "q1 is" << std::endl;
-      std::list<Polar_Point_With_Edge_Info>::iterator q1_itr;
-      for(q1_itr=q1.begin(); q1_itr!=q1.end(); q1_itr++){
-	std::cout << "[x  y  bearing  range is_first] = [" 
-		  << q1_itr->x() << "  " 
-		  << q1_itr->y() << "  " 
-		  << q1_itr->bearing() << "  " 
-		  << q1_itr->range() << "  " 
-		  << q1_itr->is_first << "]" 
-		  << std::endl;
-      }
-    }
-
-    //
-    //-------PREPARE FOR MAIN LOOP-------
-    //
-
-    //current_vertex is used to hold the event point (from q1)
-    //considered at iteration of the main loop.
-    Polar_Point_With_Edge_Info current_vertex;
-    //Note active_edge and e are not actually edges themselves, but
-    //iterators pointing to edges.  active_edge keeps track of the
-    //current edge visibile during the sweep.  e is an auxiliary
-    //variable used in calculation of k-points
-    std::list<Polar_Edge>::iterator active_edge, e;
-    //More aux vars for computing k-points.
-    Polar_Point k;
-    double k_range;
-    Line_Segment xing;
-
-    //Priority queue of edges, where higher priority indicates closer
-    //range to observer along current ray (of ray sweep).
-    Incident_Edge_Compare my_iec(observer, current_vertex, epsilon);
-    std::priority_queue<std::list<Polar_Edge>::iterator,
-                        std::vector<std::list<Polar_Edge>::iterator>,
-                        Incident_Edge_Compare> q2(my_iec);
-   
-    //Initialize main loop.
-    current_vertex = q1.front(); q1.pop_front();
-    active_edge = current_vertex.incident_edge;
-
-    if(PRINTING_DEBUG_DATA){
-      std::cout << std::endl
-		<< "\E[1;37;40m" 
-		<< "INITIALIZATION" 
-		<< "\x1b[0m" 
-		<< std::endl << std::endl
-		<< "\x1b[35m" 
-		<< "Pop first vertex off q1" 
-		<< "\x1b[0m"
-		<< ", set as current_vertex, \n"
-		<< "and set active_edge to the corresponding "
-		<< "incident edge."
-		<< std::endl;
-      print_cv_and_ae(current_vertex, active_edge); 
-    }
-
-    //Insert e into q2 as long as it doesn't contain the
-    //observer.
-    if( distance(observer,active_edge->first) > epsilon
-	and distance(observer,active_edge->second) > epsilon ){
-     
-      if(PRINTING_DEBUG_DATA){
-	std::cout << std::endl
-		  << "Push current_vertex's edge onto q2."
-		  << std::endl;
-      }
-
-      q2.push(active_edge);
-    }
-
-    if(PRINTING_DEBUG_DATA){
-      std::cout << std::endl
-		<< "\E[32m" 
-		<< "Add current_vertex to visibility polygon." 
-		<< "\x1b[0m" 
-		<< std::endl << std::endl
-		<< "\E[1;37;40m" 
-		<< "MAIN LOOP" 
-		<< "\x1b[0m" 
-		<< std::endl;
-    }
-
-    vertices_.push_back(current_vertex);
-
-    //-------BEGIN MAIN LOOP-------//
-    //
-    //Perform radial sweep by sequentially considering each vertex
-    //(event point) in q1.
-    while( !q1.empty() ){
-
-      //Pop current_vertex from q1.
-      current_vertex = q1.front(); q1.pop_front();
-
-      if(PRINTING_DEBUG_DATA){
-	std::cout << std::endl
-		  << "\x1b[35m" 
-		  << "Pop next vertex off q1" << "\x1b[0m"
-		  << " and set as current_vertex."
-		  << std::endl;
-	print_cv_and_ae(current_vertex, active_edge);
-      }
-
-      //---Handle Event Point---
-
-      //TYPE 1: current_vertex is the _second_vertex_ of active_edge.
-      if( current_vertex.incident_edge == active_edge 
-	  and !current_vertex.is_first ){
-
-	if(PRINTING_DEBUG_DATA){
-	  std::cout << std::endl
-		    << "\E[36m" << "TYPE 1:" << "\x1b[0m"
-		    << " current_vertex is the second vertex of active_edge."
-		    << std::endl;
-	}
-
-	if( !q1.empty() ){ 
-	  //If the next vertex in q1 is contiguous.
-	  if( distance( current_vertex, q1.front() ) <= epsilon ){
-
-	    if(PRINTING_DEBUG_DATA){
-	      std::cout << std::endl
-			<< "current_vertex is contiguous "
-			<< "with the next vertex in q1."
-			<< std::endl;
-	    }
-
-	    continue;
-	  }
-	}
-
-	if(PRINTING_DEBUG_DATA){
-	  std::cout << std::endl
-		    << "\E[32m" << "Add current_vertex to visibility polygon." 
-		    << "\x1b[0m" << std::endl;
-	}
-
-	//Push current_vertex onto visibility polygon 
-	vertices_.push_back( current_vertex );
-	chop_spikes_at_back(observer, epsilon);
-
-	while( !q2.empty() ){
-	  e = q2.top();
-
-	  if(PRINTING_DEBUG_DATA){
-	    std::cout << std::endl
-		      << "Examine edge at top of q2." << std::endl
-		      << "1st point of e [x  y  bearing  range] = ["
-		      << (e->first).x() << "  " 
-		      << (e->first).y() << "  "
-		      << (e->first).bearing() << "  "
-		      << (e->first).range() << "]" << std::endl
-		      << "2nd point of e [x  y  bearing  range] = [" 
-		      << (e->second).x() << "  " 
-		      << (e->second).y() << "  "
-		      << (e->second).bearing() << "  "
-		      << (e->second).range() << "]" << std::endl;
-	  }
-
-	  //If the current_vertex bearing has not passed, in the
-	  //lex. order sense, the bearing of the second point of the
-	  //edge at the front of q2.
-	  if(  ( current_vertex.bearing().get() 
-		 <= e->second.bearing().get() )
-	       //For robustness.
-	       and distance( Ray(observer, current_vertex.bearing()),
-			     e->second ) >= epsilon
-	       /* was
-	       and std::min( distance(Ray(observer, current_vertex.bearing()),
-				      e->second), 
-			     distance(Ray(observer, e->second.bearing()),
-				      current_vertex) 
-			     ) >= epsilon
-	       */
-	       ){
- 	    //Find intersection point k of ray (through
-	    //current_vertex) with edge e.
-	    xing = intersection( Ray(observer, current_vertex.bearing()), 
-				 Line_Segment(e->first,
-					      e->second),
-				 epsilon );
-	    	    
-	    //assert( xing.size() > 0 );
-	    
-	    if( xing.size() > 0 ){
-	      k = Polar_Point( observer , xing.first() );
-	    }
-	    else{ //Error contingency.
-	      k = current_vertex;
-	      e = current_vertex.incident_edge;
-	    }
-
-	    if(PRINTING_DEBUG_DATA){
-	      std::cout << std::endl
-			<< "\E[32m" 
-			<< "Add a type 1 k-point to visibility polygon." 
-			<< "\x1b[0m" << std::endl
-			<< std::endl
-			<< "Set active_edge to edge at top of q2." 
-			<< std::endl;
-	    }
-
-	    //Push k onto the visibility polygon.
-	    vertices_.push_back(k);
-	    chop_spikes_at_back(observer, epsilon);
-	    active_edge = e;
-	    break;
-	  }
-
-	  if(PRINTING_DEBUG_DATA){
-	    std::cout << std::endl
-		      << "Pop edge off top of q2." << std::endl;
-	  }
-	  
-	  q2.pop();
-	}
-      } //Close Type 1.
-
-      //If current_vertex is the _first_vertex_ of its edge.
-      if( current_vertex.is_first ){
-	//Find intersection point k of ray (through current_vertex)
-	//with active_edge.
-	xing = intersection( Ray(observer, current_vertex.bearing()), 
-			     Line_Segment(active_edge->first,
-					  active_edge->second),
-			     epsilon );
-	if(  xing.size() == 0 
-	     or ( distance(active_edge->first, observer) <= epsilon 
-		  and active_edge->second.bearing() 
-		  <= current_vertex.bearing() )
-	     or active_edge->second < current_vertex  ){
-	  k_range = INFINITY;
-	}
-	else{
-	  k = Polar_Point( observer , xing.first() );
-	  k_range = k.range();
-	}
-
-	//Incident edge of current_vertex.
-	e = current_vertex.incident_edge;
-	
-	if(PRINTING_DEBUG_DATA){
-	  std::cout << std::endl
-		    << "               k_range = " 
-		    << k_range 
-		    << " (range of active edge along "
-		    <<   "bearing of current vertex)" << std::endl
-		    << "current_vertex.range() = " 
-		    << current_vertex.range() << std::endl;
-	}
-	
-	//Insert e into q2 as long as it doesn't contain the
-	//observer.
-	if( distance(observer, e->first) > epsilon
-	    and distance(observer, e->second) > epsilon ){
-	 
-	  if(PRINTING_DEBUG_DATA){
-	    std::cout << std::endl
-		      << "Push current_vertex's edge onto q2."
-		      << std::endl;
-	  }
-	  
-	  q2.push(e);
-	}
-
-	//TYPE 2: current_vertex is (1) a first vertex of some edge
-	//other than active_edge, and (2) that edge should not become
-	//the next active_edge.  This happens, e.g., if that edge is
-	//(rangewise) in back along the current bearing.
-	if( k_range < current_vertex.range() ){
-
-	  if(PRINTING_DEBUG_DATA){
-	    std::cout << std::endl
-		      << "\E[36m" << "TYPE 2:" << "\x1b[0m"
-		      << " current_vertex is" << std::endl
-		      << "(1) a first vertex of some edge "
-	                 "other than active_edge, and" << std::endl
-		      << "(2) that edge should not become "
-		      << "the next active_edge."
-		      << std::endl;
-	 
-	  }
-
-	} //Close Type 2.
-
-	//TYPE 3: current_vertex is (1) the first vertex of some edge
-	//other than active_edge, and (2) that edge should become the
-	//next active_edge.  This happens, e.g., if that edge is
-	//(rangewise) in front along the current bearing.
-	if(  k_range >= current_vertex.range() 
-	     ){
-	  
-	  if(PRINTING_DEBUG_DATA){
-	    std::cout << std::endl
-		      << "\E[36m" << "TYPE 3:" << "\x1b[0m"
-		      << " current_vertex is" << std::endl
-		      << "(1) the first vertex of some edge "
-	                 "other than active edge, and" << std::endl
-		      << "(2) that edge should become "
-		      << "the next active_edge."
-		      << std::endl;
-	  }
-
-	  //Push k onto the visibility polygon unless effectively
-	  //contiguous with current_vertex.
-	  if( xing.size() > 0
-	      //and k == k
-	      and k_range != INFINITY
-	      and distance(k, current_vertex) > epsilon 
-	      and distance(active_edge->first, observer) > epsilon 
-	      ){
-	   
-	    if(PRINTING_DEBUG_DATA){
-	      std::cout << std::endl
-			<< "\E[32m" 
-			<< "Add type 3 k-point to visibility polygon." 
-			<< "\x1b[0m" << std::endl;
-	    }
-
-	    //Push k-point onto the visibility polygon.
-	    vertices_.push_back(k);
-	    chop_spikes_at_back(observer, epsilon);
-	  }
-
-	  //Push current_vertex onto the visibility polygon.
-	  vertices_.push_back(current_vertex);
-	  chop_spikes_at_back(observer, epsilon);
-	  //Set active_edge to edge of current_vertex.
-	  active_edge = e;
-
-	  if(PRINTING_DEBUG_DATA){
-	    std::cout << std::endl
-		      << "\E[32m" << "Add current_vertex to visibility polygon." 
-		      << "\x1b[0m" << std::endl
-		      << std::endl
-		      << "Set active_edge to edge of current_vertex." 
-		      << std::endl;
-	  }
-
-	} //Close Type 3.
-      }
-      
-      if(PRINTING_DEBUG_DATA){
-	std::cout << std::endl
-		  << "visibility polygon vertices so far are \n"
-		  << Polygon(vertices_) << std::endl
-		  << std::endl;
-      }
-    }                            //
-                                 //
-    //-------END MAIN LOOP-------//
-  
-    //The Visibility_Polygon should have a minimal representation
-    chop_spikes_at_wrap_around( observer , epsilon );
-    eliminate_redundant_vertices( epsilon );
-    chop_spikes( observer, epsilon );
-    enforce_standard_form();
-    
-    if(PRINTING_DEBUG_DATA){
-      std::cout << std::endl
-		<< "Final visibility polygon vertices are \n"
-		<< Polygon(vertices_) << std::endl
-		<< std::endl;      
-    }
-
-  }
-  Visibility_Polygon::Visibility_Polygon(const Point& observer,
-					 const Polygon& polygon_temp,
-					 double epsilon)
-  {
-    *this = Visibility_Polygon( observer, Environment(polygon_temp), epsilon );
-  }
-
-
-  //Visibility_Graph
-
-
-  Visibility_Graph::Visibility_Graph( const Visibility_Graph& vg2 )
-  {
-    n_ = vg2.n_;
-    vertex_counts_ = vg2.vertex_counts_;
-
-    //Allocate adjacency matrix
-    adjacency_matrix_ = new bool*[n_];
-    adjacency_matrix_[0] = new bool[n_*n_];
-    for(unsigned i=1; i<n_; i++)
-      adjacency_matrix_[i] = adjacency_matrix_[i-1] + n_;
-
-    //copy each entry
-    for(unsigned i=0; i<n_; i++){
-    for(unsigned j=0; j<n_; j++){
-      adjacency_matrix_[i][j] 
-	= vg2.adjacency_matrix_[i][j];
-    }}
-  }
-
-
-  Visibility_Graph::Visibility_Graph(const Environment& environment,
-				     double epsilon)
-  {
-    n_ = environment.n();
-
-    //fill vertex_counts_
-    vertex_counts_.reserve( environment.h() );
-    for(unsigned i=0; i<environment.h(); i++)
-      vertex_counts_.push_back( environment[i].n() );
-
-    //allocate a contiguous chunk of memory for adjacency_matrix_
-    adjacency_matrix_ = new bool*[n_];
-    adjacency_matrix_[0] = new bool[n_*n_];
-    for(unsigned i=1; i<n_; i++)
-      adjacency_matrix_[i] = adjacency_matrix_[i-1] + n_;
-    
-    // fill adjacency matrix by checking for inclusion in the
-    // visibility polygons
-    Polygon polygon_temp;
-    for(unsigned k1=0; k1<n_; k1++){
-      polygon_temp = Visibility_Polygon( environment(k1),
-					 environment,
-					 epsilon );
-      for(unsigned k2=0; k2<n_; k2++){
-	if( k1 == k2 )
-	  adjacency_matrix_[ k1 ][ k1 ] = true;
-	else
-	  adjacency_matrix_[ k1 ][ k2 ] =
-	    adjacency_matrix_[ k2 ][ k1 ] =    
-	    environment(k2).in( polygon_temp , epsilon ); 
-      }
-    }
-  }
-
-
-  Visibility_Graph::Visibility_Graph(const std::vector<Point> points,
-				     const Environment& environment,
-				     double epsilon)
-  {
-    n_ = points.size();
-
-    //fill vertex_counts_
-    vertex_counts_.push_back( n_ );
-
-    //allocate a contiguous chunk of memory for adjacency_matrix_
-    adjacency_matrix_ = new bool*[n_];
-    adjacency_matrix_[0] = new bool[n_*n_];
-    for(unsigned i=1; i<n_; i++)
-      adjacency_matrix_[i] = adjacency_matrix_[i-1] + n_;
-    
-    // fill adjacency matrix by checking for inclusion in the
-    // visibility polygons
-    Polygon polygon_temp;
-    for(unsigned k1=0; k1<n_; k1++){
-      polygon_temp = Visibility_Polygon( points[k1],
-					 environment,
-					 epsilon );
-      for(unsigned k2=0; k2<n_; k2++){
-	if( k1 == k2 )
-	  adjacency_matrix_[ k1 ][ k1 ] = true;
-	else
-	  adjacency_matrix_[ k1 ][ k2 ] =
-	    adjacency_matrix_[ k2 ][ k1 ] =    
-	    points[k2].in( polygon_temp , epsilon ); 
-      }
-    }
-  }
-
-  
-  Visibility_Graph::Visibility_Graph(const Guards& guards,
-				     const Environment& environment, 
-				     double epsilon)
-  {
-    *this = Visibility_Graph( guards.positions_,
-			      environment, 
-			      epsilon );
-  }
-  
-  
-  bool Visibility_Graph::operator () (unsigned i1,
-				      unsigned j1,
-				      unsigned i2,
-				      unsigned j2) const 
-  {
-    return adjacency_matrix_[ two_to_one(i1,j1) ][ two_to_one(i2,j2) ];
-  }
-  bool Visibility_Graph::operator () (unsigned k1,
-				      unsigned k2) const 
-  {
-    return adjacency_matrix_[ k1 ][ k2 ];
-  }
-  bool& Visibility_Graph::operator () (unsigned i1,
-				       unsigned j1,
-				       unsigned i2,
-				       unsigned j2)
-  {
-    return adjacency_matrix_[ two_to_one(i1,j1) ][ two_to_one(i2,j2) ];
-  }
-  bool& Visibility_Graph::operator () (unsigned k1,
-				       unsigned k2)
-  {
-    return adjacency_matrix_[ k1 ][ k2 ];
-  }
-
-
-  Visibility_Graph& Visibility_Graph::operator = 
-  (const Visibility_Graph& visibility_graph_temp)
-  {
-    if( this == &visibility_graph_temp )
-      return *this;
-    
-    n_ = visibility_graph_temp.n_;
-    vertex_counts_ = visibility_graph_temp.vertex_counts_;
-
-    //resize adjacency_matrix_
-    if( adjacency_matrix_ != NULL ){
-      delete [] adjacency_matrix_[0];
-      delete [] adjacency_matrix_; 
-    }
-    adjacency_matrix_ = new bool*[n_];
-    adjacency_matrix_[0] = new bool[n_*n_];
-    for(unsigned i=1; i<n_; i++)
-      adjacency_matrix_[i] = adjacency_matrix_[i-1] + n_;
-
-    //copy each entry
-    for(unsigned i=0; i<n_; i++){
-    for(unsigned j=0; j<n_; j++){
-      adjacency_matrix_[i][j] 
-	= visibility_graph_temp.adjacency_matrix_[i][j];
-    }}
-    
-    return *this;
-  }
-  
-  
-  unsigned Visibility_Graph::two_to_one(unsigned i,
-					unsigned j) const
-  {
-    unsigned k=0;
-
-    for(unsigned counter=0; counter<i; counter++)
-      k += vertex_counts_[counter];
-    k += j;
-
-    return k;
-  }
-
-
-  Visibility_Graph::~Visibility_Graph()    
-  { 
-    if( adjacency_matrix_ != NULL ){
-      delete [] adjacency_matrix_[0];
-      delete [] adjacency_matrix_; 
-    }
-  }
-
-
-  std::ostream& operator << (std::ostream& outs,
-			     const Visibility_Graph& visibility_graph)
-  {
-    for(unsigned k1=0; k1<visibility_graph.n(); k1++){
-      for(unsigned k2=0; k2<visibility_graph.n(); k2++){
-	outs << visibility_graph( k1, k2 );
-	if( k2 < visibility_graph.n()-1 )
-	  outs << "  ";
-	else
-	  outs << std::endl;
-      }
-    }
-
-    return outs;
-  }
-
 }
+
+std::pair<unsigned, unsigned> Environment::one_to_two(unsigned k) const {
+  std::pair<unsigned, unsigned> two(0, 0);
+  // Strategy: add up vertex count of each Polygon (outer boundary +
+  // holes) until greater than k
+  unsigned current_polygon_index = 0;
+  unsigned vertex_count_up_to_current_polygon = (*this)[0].n();
+  unsigned vertex_count_up_to_last_polygon = 0;
+
+  while (k >= vertex_count_up_to_current_polygon and
+         current_polygon_index < (*this).h()) {
+    current_polygon_index++;
+    two.first = two.first + 1;
+    vertex_count_up_to_last_polygon = vertex_count_up_to_current_polygon;
+    vertex_count_up_to_current_polygon += (*this)[current_polygon_index].n();
+  }
+  two.second = k - vertex_count_up_to_last_polygon;
+
+  return two;
+}
+
+std::ostream &operator<<(std::ostream &outs,
+                         const Environment &environment_temp) {
+  outs << "//Environment Model" << std::endl;
+  outs << "//Outer Boundary" << std::endl << environment_temp[0];
+  for (unsigned i = 1; i <= environment_temp.h(); i++) {
+    outs << "//Hole" << std::endl << environment_temp[i];
+  }
+  // outs << "//EOF marker";
+  return outs;
+}
+
+// Guards
+
+Guards::Guards(const std::string &filename) {
+  std::ifstream fin(filename.c_str());
+  // if(fin.fail()) { std::cerr << "\x1b[5;31m" << "Input file
+  // opening failed." << "\x1b[0m\n" << "\a \n"; exit(1);}
+  assert(!fin.fail());
+
+  // Temp vars for numbers to be read from file.
+  double x_temp, y_temp;
+
+  // Skip comments
+  while (fin.peek() == '/')
+    fin.ignore(200, '\n');
+
+  // Read positions.
+  while (1) {
+    fin >> x_temp >> y_temp;
+    if (fin.eof()) {
+      fin.close();
+      return;
+    }
+    positions_.push_back(Point(x_temp, y_temp));
+    // Skip to next line.
+    fin.ignore(1);
+    // Skip comments
+    while (fin.peek() == '/')
+      fin.ignore(200, '\n');
+  }
+}
+
+bool Guards::are_lex_ordered() const {
+  // if more than one guard.
+  if (positions_.size() > 1)
+    for (unsigned i = 0; i < positions_.size() - 1; i++)
+      if (positions_[i] > positions_[i + 1])
+        return false;
+  return true;
+}
+
+bool Guards::noncolocated(double epsilon) const {
+  for (unsigned i = 0; i < positions_.size(); i++)
+    for (unsigned j = i + 1; j < positions_.size(); j++)
+      if (distance(positions_[i], positions_[j]) <= epsilon)
+        return false;
+  return true;
+}
+
+bool Guards::in(const Polygon &polygon_temp, double epsilon) const {
+  for (unsigned i = 0; i < positions_.size(); i++)
+    if (!positions_[i].in(polygon_temp, epsilon))
+      return false;
+  return true;
+}
+
+bool Guards::in(const Environment &environment_temp, double epsilon) const {
+  for (unsigned i = 0; i < positions_.size(); i++)
+    if (!positions_[i].in(environment_temp, epsilon))
+      return false;
+  return true;
+}
+
+double Guards::diameter() const {
+  // Precondition:  more than 0 guards
+  assert(N() > 0);
+
+  double running_max = 0;
+  for (unsigned i = 0; i < N() - 1; i++) {
+    for (unsigned j = i + 1; j < N(); j++) {
+      if (distance((*this)[i], (*this)[j]) > running_max)
+        running_max = distance((*this)[i], (*this)[j]);
+    }
+  }
+  return running_max;
+}
+
+Bounding_Box Guards::bbox() const {
+  // Precondition:  nonempty Guard set
+  assert(positions_.size() > 0);
+
+  Bounding_Box bounding_box;
+  double x_min = positions_[0].x(), x_max = positions_[0].x(),
+         y_min = positions_[0].y(), y_max = positions_[0].y();
+  for (unsigned i = 1; i < positions_.size(); i++) {
+    if (x_min > positions_[i].x()) {
+      x_min = positions_[i].x();
+    }
+    if (x_max < positions_[i].x()) {
+      x_max = positions_[i].x();
+    }
+    if (y_min > positions_[i].y()) {
+      y_min = positions_[i].y();
+    }
+    if (y_max < positions_[i].y()) {
+      y_max = positions_[i].y();
+    }
+  }
+  bounding_box.x_min = x_min;
+  bounding_box.x_max = x_max;
+  bounding_box.y_min = y_min;
+  bounding_box.y_max = y_max;
+  return bounding_box;
+}
+
+void Guards::write_to_file(const std::string &filename,
+                           int fios_precision_temp) {
+  assert(fios_precision_temp >= 1);
+
+  std::ofstream fout(filename.c_str());
+  // fout.open( filename.c_str() );  //Alternatives.
+  // fout << *this;
+  fout.setf(std::ios::fixed);
+  fout.setf(std::ios::showpoint);
+  fout.precision(fios_precision_temp);
+  fout << "//Guard Positions" << std::endl;
+  for (unsigned i = 0; i < positions_.size(); i++)
+    fout << positions_[i].x() << "  " << positions_[i].y() << std::endl;
+  // fout << "//EOF marker";
+  fout.close();
+}
+
+void Guards::enforce_lex_order() {
+  // std::stable_sort(positions_.begin(), positions_.end());
+  std::sort(positions_.begin(), positions_.end());
+}
+
+void Guards::reverse() { std::reverse(positions_.begin(), positions_.end()); }
+
+void Guards::snap_to_vertices_of(const Environment &environment_temp,
+                                 double epsilon) {
+  for (unsigned i = 0; i < positions_.size(); i++)
+    positions_[i].snap_to_vertices_of(environment_temp);
+}
+
+void Guards::snap_to_vertices_of(const Polygon &polygon_temp, double epsilon) {
+  for (unsigned i = 0; i < positions_.size(); i++)
+    positions_[i].snap_to_vertices_of(polygon_temp);
+}
+
+void Guards::snap_to_boundary_of(const Environment &environment_temp,
+                                 double epsilon) {
+  for (unsigned i = 0; i < positions_.size(); i++)
+    positions_[i].snap_to_boundary_of(environment_temp);
+}
+
+void Guards::snap_to_boundary_of(const Polygon &polygon_temp, double epsilon) {
+  for (unsigned i = 0; i < positions_.size(); i++)
+    positions_[i].snap_to_boundary_of(polygon_temp);
+}
+
+std::ostream &operator<<(std::ostream &outs, const Guards &guards) {
+  outs << "//Guard Positions" << std::endl;
+  for (unsigned i = 0; i < guards.N(); i++)
+    outs << guards[i].x() << "  " << guards[i].y() << std::endl;
+  // outs << "//EOF marker";
+  return outs;
+}
+
+// Visibility_Polygon
+
+bool Visibility_Polygon::is_spike(const Point &observer, const Point &point1,
+                                  const Point &point2, const Point &point3,
+                                  double epsilon) const {
+
+  return (
+      // Make sure observer not colocated with any of the points.
+      distance(observer, point1) > epsilon and
+      distance(observer, point2) > epsilon and
+      distance(observer, point3) > epsilon
+      // Test whether there is a spike with point2 as the tip
+      and ((distance(observer, point2) >= distance(observer, point1) and
+            distance(observer, point2) >= distance(observer, point3)) or
+           (distance(observer, point2) <= distance(observer, point1) and
+            distance(observer, point2) <= distance(observer, point3)))
+      // and the pike is sufficiently sharp,
+      and std::max(distance(Ray(observer, point1), point2),
+                   distance(Ray(observer, point3), point2)) <= epsilon);
+  // Formerly used
+  // std::fabs( Polygon(point1, point2, point3).area() ) < epsilon
+}
+
+void Visibility_Polygon::chop_spikes_at_back(const Point &observer,
+                                             double epsilon) {
+  // Eliminate "special case" vertices of the visibility polygon.
+  // While the top three vertices form a spike.
+  while (vertices_.size() >= 3 and
+         is_spike(observer, vertices_[vertices_.size() - 3],
+                  vertices_[vertices_.size() - 2],
+                  vertices_[vertices_.size() - 1], epsilon)) {
+    vertices_[vertices_.size() - 2] = vertices_[vertices_.size() - 1];
+    vertices_.pop_back();
+  }
+}
+
+void Visibility_Polygon::chop_spikes_at_wrap_around(const Point &observer,
+                                                    double epsilon) {
+  // Eliminate "special case" vertices of the visibility polygon at
+  // wrap-around.  While the there's a spike at the wrap-around,
+  while (vertices_.size() >= 3 and
+         is_spike(observer, vertices_[vertices_.size() - 2],
+                  vertices_[vertices_.size() - 1], vertices_[0], epsilon)) {
+    // Chop off the tip of the spike.
+    vertices_.pop_back();
+  }
+}
+
+void Visibility_Polygon::chop_spikes(const Point &observer, double epsilon) {
+  std::set<Point> spike_tips;
+  std::vector<Point> vertices_temp;
+  // Middle point is potentially the tip of a spike
+  for (unsigned i = 0; i < vertices_.size(); i++)
+    if (distance((*this)[i + 2], Line_Segment((*this)[i], (*this)[i + 1])) <=
+            epsilon or
+        distance((*this)[i], Line_Segment((*this)[i + 1], (*this)[i + 2])) <=
+            epsilon)
+      spike_tips.insert((*this)[i + 1]);
+
+  for (unsigned i = 0; i < vertices_.size(); i++)
+    if (spike_tips.find(vertices_[i]) == spike_tips.end())
+      vertices_temp.push_back(vertices_[i]);
+  vertices_.swap(vertices_temp);
+}
+
+void Visibility_Polygon::print_cv_and_ae(
+    const Polar_Point_With_Edge_Info &current_vertex,
+    const std::list<Polar_Edge>::iterator &active_edge) {
+  std::cout << "           current_vertex [x  y  bearing  range is_first] = ["
+            << current_vertex.x() << "  " << current_vertex.y() << "  "
+            << current_vertex.bearing() << "  " << current_vertex.range()
+            << "  " << current_vertex.is_first << "]" << std::endl;
+  std::cout << "1st point of current_vertex's edge [x  y  bearing  range] = ["
+            << (current_vertex.incident_edge->first).x() << "  "
+            << (current_vertex.incident_edge->first).y() << "  "
+            << (current_vertex.incident_edge->first).bearing() << "  "
+            << (current_vertex.incident_edge->first).range() << "]"
+            << std::endl;
+  std::cout << "2nd point of current_vertex's edge [x  y  bearing  range] = ["
+            << (current_vertex.incident_edge->second).x() << "  "
+            << (current_vertex.incident_edge->second).y() << "  "
+            << (current_vertex.incident_edge->second).bearing() << "  "
+            << (current_vertex.incident_edge->second).range() << "]"
+            << std::endl;
+  std::cout << "          1st point of active_edge [x  y  bearing  range] = ["
+            << (active_edge->first).x() << "  " << (active_edge->first).y()
+            << "  " << (active_edge->first).bearing() << "  "
+            << (active_edge->first).range() << "]" << std::endl;
+  std::cout << "          2nd point of active_edge [x  y  bearing  range] = ["
+            << (active_edge->second).x() << "  " << (active_edge->second).y()
+            << "  " << (active_edge->second).bearing() << "  "
+            << (active_edge->second).range() << "]" << std::endl;
+}
+
+Visibility_Polygon::Visibility_Polygon(const Point &observer,
+                                       const Environment &environment_temp,
+                                       double epsilon)
+    : observer_(observer) {
+  // Visibility polygon algorithm for environments with holes
+  // Radial line (AKA angular plane) sweep technique.
+  //
+  // Based on algorithms described in
+  //
+  //[1] "Automated Camera Layout to Satisfy Task-Specific and
+  // Floorplan-Specific Coverage Requirements" by Ugur Murat Erdem
+  // and Stan Scarloff, April 15, 2004
+  // available at BUCS Technical Report Archive:
+  // http://www.cs.bu.edu/techreports/pdf/2004-015-camera-layout.pdf
+  //
+  //[2] "Art Gallery Theorems and Algorithms" by Joseph O'Rourke
+  //
+  //[3] "Visibility Algorithms in the Plane" by Ghosh
+  //
+
+  // We define a k-point is a point seen on the other side of a
+  // visibility occluding corner.  This name is appropriate because
+  // the vertical line in the letter "k" is like a line-of-sight past
+  // the corner of the "k".
+
+  //
+  // Preconditions:
+  //(1)  the Environment is epsilon-valid,
+  //(2)  the Point observer is actually in the Environment
+  //     environment_temp,
+  //(3)  the guard has been epsilon-snapped to the boundary, followed
+  //     by vertices of the environment (the order of the snapping
+  //     is important).
+  //
+  //:WARNING:
+  // For efficiency, the assertions corresponding to these
+  // preconditions have been excluded.
+  //
+  // assert( environment_temp.is_valid(epsilon) );
+  // assert( environment_temp.is_in_standard_form() );
+  // assert( observer.in(environment_temp, epsilon) );
+
+  // true  => data printed to terminal
+  // false => silent
+  const bool PRINTING_DEBUG_DATA = false;
+
+  // The visibility polygon cannot have more vertices than the environment.
+  vertices_.reserve(environment_temp.n());
+
+  //
+  //--------PREPROCESSING--------
+  //
+
+  // Construct a POLAR EDGE LIST from environment_temp's outer
+  // boundary and holes.  During this construction, those edges are
+  // split which either (1) cross the ray emanating from the observer
+  // parallel to the x-axis (of world coords), or (2) contain the
+  // observer in their relative interior (w/in epsilon).  Also, edges
+  // having first vertex bearing >= second vertex bearing are
+  // eliminated because they cannot possibly contribute to the
+  // visibility polygon.
+  std::list<Polar_Edge> elp;
+  Polar_Point ppoint1, ppoint2;
+  Polar_Point split_bottom, split_top;
+  double t;
+  // If the observer is standing on the Enviroment boundary with its
+  // back to the wall, these will be the bearings of the next vertex
+  // to the right and to the left, respectively.
+  Angle right_wall_bearing;
+  Angle left_wall_bearing;
+  for (unsigned i = 0; i <= environment_temp.h(); i++) {
+    for (unsigned j = 0; j < environment_temp[i].n(); j++) {
+      ppoint1 = Polar_Point(observer, environment_temp[i][j]);
+      ppoint2 = Polar_Point(observer, environment_temp[i][j + 1]);
+
+      // If the observer is in the relative interior of the edge.
+      if (observer.in_relative_interior_of(Line_Segment(ppoint1, ppoint2),
+                                           epsilon)) {
+        // Split the edge at the observer and add the resulting two
+        // edges to elp (the polar edge list).
+        split_bottom = Polar_Point(observer, observer);
+        split_top = Polar_Point(observer, observer);
+
+        if (ppoint2.bearing() == Angle(0.0))
+          ppoint2.set_bearing_to_2pi();
+
+        left_wall_bearing = ppoint1.bearing();
+        right_wall_bearing = ppoint2.bearing();
+
+        elp.push_back(Polar_Edge(ppoint1, split_bottom));
+        elp.push_back(Polar_Edge(split_top, ppoint2));
+        continue;
+      }
+
+      // Else if the observer is on first vertex of edge.
+      else if (distance(observer, ppoint1) <= epsilon) {
+        if (ppoint2.bearing() == Angle(0.0))
+          ppoint2.set_bearing_to_2pi();
+        // Get right wall bearing.
+        right_wall_bearing = ppoint2.bearing();
+        elp.push_back(Polar_Edge(Polar_Point(observer, observer), ppoint2));
+        continue;
+      }
+      // Else if the observer is on second vertex of edge.
+      else if (distance(observer, ppoint2) <= epsilon) {
+        // Get left wall bearing.
+        left_wall_bearing = ppoint1.bearing();
+        elp.push_back(Polar_Edge(ppoint1, Polar_Point(observer, observer)));
+        continue;
+      }
+
+      // Otherwise the observer is not on the edge.
+
+      // If edge not horizontal (w/in epsilon).
+      else if (std::fabs(ppoint1.y() - ppoint2.y()) > epsilon) {
+        // Possible source of numerical instability?
+        t = (observer.y() - ppoint2.y()) / (ppoint1.y() - ppoint2.y());
+        // If edge crosses the ray emanating horizontal and right of
+        // the observer.
+        if (0 < t and t < 1 and
+            observer.x() < t * ppoint1.x() + (1 - t) * ppoint2.x()) {
+          // If first point is above, omit edge because it runs
+          //'against the grain'.
+          if (ppoint1.y() > observer.y())
+            continue;
+          // Otherwise split the edge, making sure angles are assigned
+          // correctly on each side of the split point.
+          split_bottom = split_top = Polar_Point(
+              observer,
+              Point(t * ppoint1.x() + (1 - t) * ppoint2.x(), observer.y()));
+          split_top.set_bearing(Angle(0.0));
+          split_bottom.set_bearing_to_2pi();
+          elp.push_back(Polar_Edge(ppoint1, split_bottom));
+          elp.push_back(Polar_Edge(split_top, ppoint2));
+          continue;
+        }
+        // If the edge is not horizontal and doesn't cross the ray
+        // emanating horizontal and right of the observer.
+        else if (ppoint1.bearing() >= ppoint2.bearing() and
+                 ppoint2.bearing() == Angle(0.0) and
+                 ppoint1.bearing() > Angle(M_PI))
+          ppoint2.set_bearing_to_2pi();
+        // Filter out edges which run 'against the grain'.
+        else if ((ppoint1.bearing() == Angle(0, 0) and
+                  ppoint2.bearing() > Angle(M_PI)) or
+                 ppoint1.bearing() >= ppoint2.bearing())
+          continue;
+        elp.push_back(Polar_Edge(ppoint1, ppoint2));
+        continue;
+      }
+      // If edge is horizontal (w/in epsilon).
+      else {
+        // Filter out edges which run 'against the grain'.
+        if (ppoint1.bearing() >= ppoint2.bearing())
+          continue;
+        elp.push_back(Polar_Edge(ppoint1, ppoint2));
+      }
+    }
+  }
+
+  // Construct a SORTED LIST, q1, OF VERTICES represented by
+  // Polar_Point_With_Edge_Info objects.  A
+  // Polar_Point_With_Edge_Info is a derived class of Polar_Point
+  // which includes (1) a pointer to the corresponding edge
+  //(represented as a Polar_Edge) in the polar edge list elp, and
+  //(2) a boolean (is_first) which is true iff that vertex is the
+  // first Point of the respective edge (is_first == false => it's
+  // second Point).  q1 is sorted according to lex. order of polar
+  // coordinates just as Polar_Points are, but with the additional
+  // requirement that if two vertices have equal polar coordinates,
+  // the vertex which is the first point of its respective edge is
+  // considered greater.  q1 will serve as an event point queue for
+  // the radial sweep.
+  std::list<Polar_Point_With_Edge_Info> q1;
+  Polar_Point_With_Edge_Info ppoint_wei1, ppoint_wei2;
+  std::list<Polar_Edge>::iterator elp_iterator;
+  for (elp_iterator = elp.begin(); elp_iterator != elp.end(); elp_iterator++) {
+    ppoint_wei1.set_polar_point(elp_iterator->first);
+    ppoint_wei1.incident_edge = elp_iterator;
+    ppoint_wei1.is_first = true;
+    ppoint_wei2.set_polar_point(elp_iterator->second);
+    ppoint_wei2.incident_edge = elp_iterator;
+    ppoint_wei2.is_first = false;
+    // If edge contains the observer, then adjust the bearing of
+    // the Polar_Point containing the observer.
+    if (distance(observer, ppoint_wei1) <= epsilon) {
+      if (right_wall_bearing > left_wall_bearing) {
+        ppoint_wei1.set_bearing(right_wall_bearing);
+        (elp_iterator->first).set_bearing(right_wall_bearing);
+      } else {
+        ppoint_wei1.set_bearing(Angle(0.0));
+        (elp_iterator->first).set_bearing(Angle(0.0));
+      }
+    } else if (distance(observer, ppoint_wei2) <= epsilon) {
+      if (right_wall_bearing > left_wall_bearing) {
+        ppoint_wei2.set_bearing(right_wall_bearing);
+        (elp_iterator->second).set_bearing(right_wall_bearing);
+      } else {
+        ppoint_wei2.set_bearing_to_2pi();
+        (elp_iterator->second).set_bearing_to_2pi();
+      }
+    }
+    q1.push_back(ppoint_wei1);
+    q1.push_back(ppoint_wei2);
+  }
+  // Put event point in correct order.
+  // STL list's sort method is a stable sort.
+  q1.sort();
+
+  if (PRINTING_DEBUG_DATA) {
+    std::cout << std::endl
+              << "\E[1;37;40m"
+              << "COMPUTING VISIBILITY POLYGON " << std::endl
+              << "for an observer located at [x y] = [" << observer << "]"
+              << "\x1b[0m" << std::endl
+              << std::endl
+              << "\E[1;37;40m"
+              << "PREPROCESSING"
+              << "\x1b[0m" << std::endl
+              << std::endl
+              << "q1 is" << std::endl;
+    std::list<Polar_Point_With_Edge_Info>::iterator q1_itr;
+    for (q1_itr = q1.begin(); q1_itr != q1.end(); q1_itr++) {
+      std::cout << "[x  y  bearing  range is_first] = [" << q1_itr->x() << "  "
+                << q1_itr->y() << "  " << q1_itr->bearing() << "  "
+                << q1_itr->range() << "  " << q1_itr->is_first << "]"
+                << std::endl;
+    }
+  }
+
+  //
+  //-------PREPARE FOR MAIN LOOP-------
+  //
+
+  // current_vertex is used to hold the event point (from q1)
+  // considered at iteration of the main loop.
+  Polar_Point_With_Edge_Info current_vertex;
+  // Note active_edge and e are not actually edges themselves, but
+  // iterators pointing to edges.  active_edge keeps track of the
+  // current edge visibile during the sweep.  e is an auxiliary
+  // variable used in calculation of k-points
+  std::list<Polar_Edge>::iterator active_edge, e;
+  // More aux vars for computing k-points.
+  Polar_Point k;
+  double k_range;
+  Line_Segment xing;
+
+  // Priority queue of edges, where higher priority indicates closer
+  // range to observer along current ray (of ray sweep).
+  Incident_Edge_Compare my_iec(observer, current_vertex, epsilon);
+  std::priority_queue<std::list<Polar_Edge>::iterator,
+                      std::vector<std::list<Polar_Edge>::iterator>,
+                      Incident_Edge_Compare>
+      q2(my_iec);
+
+  // Initialize main loop.
+  current_vertex = q1.front();
+  q1.pop_front();
+  active_edge = current_vertex.incident_edge;
+
+  if (PRINTING_DEBUG_DATA) {
+    std::cout << std::endl
+              << "\E[1;37;40m"
+              << "INITIALIZATION"
+              << "\x1b[0m" << std::endl
+              << std::endl
+              << "\x1b[35m"
+              << "Pop first vertex off q1"
+              << "\x1b[0m"
+              << ", set as current_vertex, \n"
+              << "and set active_edge to the corresponding "
+              << "incident edge." << std::endl;
+    print_cv_and_ae(current_vertex, active_edge);
+  }
+
+  // Insert e into q2 as long as it doesn't contain the
+  // observer.
+  if (distance(observer, active_edge->first) > epsilon and
+      distance(observer, active_edge->second) > epsilon) {
+
+    if (PRINTING_DEBUG_DATA) {
+      std::cout << std::endl
+                << "Push current_vertex's edge onto q2." << std::endl;
+    }
+
+    q2.push(active_edge);
+  }
+
+  if (PRINTING_DEBUG_DATA) {
+    std::cout << std::endl
+              << "\E[32m"
+              << "Add current_vertex to visibility polygon."
+              << "\x1b[0m" << std::endl
+              << std::endl
+              << "\E[1;37;40m"
+              << "MAIN LOOP"
+              << "\x1b[0m" << std::endl;
+  }
+
+  vertices_.push_back(current_vertex);
+
+  //-------BEGIN MAIN LOOP-------//
+  //
+  // Perform radial sweep by sequentially considering each vertex
+  //(event point) in q1.
+  while (!q1.empty()) {
+
+    // Pop current_vertex from q1.
+    current_vertex = q1.front();
+    q1.pop_front();
+
+    if (PRINTING_DEBUG_DATA) {
+      std::cout << std::endl
+                << "\x1b[35m"
+                << "Pop next vertex off q1"
+                << "\x1b[0m"
+                << " and set as current_vertex." << std::endl;
+      print_cv_and_ae(current_vertex, active_edge);
+    }
+
+    //---Handle Event Point---
+
+    // TYPE 1: current_vertex is the _second_vertex_ of active_edge.
+    if (current_vertex.incident_edge == active_edge and
+        !current_vertex.is_first) {
+
+      if (PRINTING_DEBUG_DATA) {
+        std::cout << std::endl
+                  << "\E[36m"
+                  << "TYPE 1:"
+                  << "\x1b[0m"
+                  << " current_vertex is the second vertex of active_edge."
+                  << std::endl;
+      }
+
+      if (!q1.empty()) {
+        // If the next vertex in q1 is contiguous.
+        if (distance(current_vertex, q1.front()) <= epsilon) {
+
+          if (PRINTING_DEBUG_DATA) {
+            std::cout << std::endl
+                      << "current_vertex is contiguous "
+                      << "with the next vertex in q1." << std::endl;
+          }
+
+          continue;
+        }
+      }
+
+      if (PRINTING_DEBUG_DATA) {
+        std::cout << std::endl
+                  << "\E[32m"
+                  << "Add current_vertex to visibility polygon."
+                  << "\x1b[0m" << std::endl;
+      }
+
+      // Push current_vertex onto visibility polygon
+      vertices_.push_back(current_vertex);
+      chop_spikes_at_back(observer, epsilon);
+
+      while (!q2.empty()) {
+        e = q2.top();
+
+        if (PRINTING_DEBUG_DATA) {
+          std::cout << std::endl
+                    << "Examine edge at top of q2." << std::endl
+                    << "1st point of e [x  y  bearing  range] = ["
+                    << (e->first).x() << "  " << (e->first).y() << "  "
+                    << (e->first).bearing() << "  " << (e->first).range() << "]"
+                    << std::endl
+                    << "2nd point of e [x  y  bearing  range] = ["
+                    << (e->second).x() << "  " << (e->second).y() << "  "
+                    << (e->second).bearing() << "  " << (e->second).range()
+                    << "]" << std::endl;
+        }
+
+        // If the current_vertex bearing has not passed, in the
+        // lex. order sense, the bearing of the second point of the
+        // edge at the front of q2.
+        if ((current_vertex.bearing().get() <= e->second.bearing().get())
+            // For robustness.
+            and distance(Ray(observer, current_vertex.bearing()), e->second) >=
+                    epsilon
+            /* was
+            and std::min( distance(Ray(observer, current_vertex.bearing()),
+                                   e->second),
+                          distance(Ray(observer, e->second.bearing()),
+                                   current_vertex)
+                          ) >= epsilon
+            */
+        ) {
+          // Find intersection point k of ray (through
+          // current_vertex) with edge e.
+          xing = intersection(Ray(observer, current_vertex.bearing()),
+                              Line_Segment(e->first, e->second), epsilon);
+
+          // assert( xing.size() > 0 );
+
+          if (xing.size() > 0) {
+            k = Polar_Point(observer, xing.first());
+          } else { // Error contingency.
+            k = current_vertex;
+            e = current_vertex.incident_edge;
+          }
+
+          if (PRINTING_DEBUG_DATA) {
+            std::cout << std::endl
+                      << "\E[32m"
+                      << "Add a type 1 k-point to visibility polygon."
+                      << "\x1b[0m" << std::endl
+                      << std::endl
+                      << "Set active_edge to edge at top of q2." << std::endl;
+          }
+
+          // Push k onto the visibility polygon.
+          vertices_.push_back(k);
+          chop_spikes_at_back(observer, epsilon);
+          active_edge = e;
+          break;
+        }
+
+        if (PRINTING_DEBUG_DATA) {
+          std::cout << std::endl << "Pop edge off top of q2." << std::endl;
+        }
+
+        q2.pop();
+      }
+    } // Close Type 1.
+
+    // If current_vertex is the _first_vertex_ of its edge.
+    if (current_vertex.is_first) {
+      // Find intersection point k of ray (through current_vertex)
+      // with active_edge.
+      xing = intersection(Ray(observer, current_vertex.bearing()),
+                          Line_Segment(active_edge->first, active_edge->second),
+                          epsilon);
+      if (xing.size() == 0 or
+          (distance(active_edge->first, observer) <= epsilon and
+           active_edge->second.bearing() <= current_vertex.bearing()) or
+          active_edge->second < current_vertex) {
+        k_range = INFINITY;
+      } else {
+        k = Polar_Point(observer, xing.first());
+        k_range = k.range();
+      }
+
+      // Incident edge of current_vertex.
+      e = current_vertex.incident_edge;
+
+      if (PRINTING_DEBUG_DATA) {
+        std::cout << std::endl
+                  << "               k_range = " << k_range
+                  << " (range of active edge along "
+                  << "bearing of current vertex)" << std::endl
+                  << "current_vertex.range() = " << current_vertex.range()
+                  << std::endl;
+      }
+
+      // Insert e into q2 as long as it doesn't contain the
+      // observer.
+      if (distance(observer, e->first) > epsilon and
+          distance(observer, e->second) > epsilon) {
+
+        if (PRINTING_DEBUG_DATA) {
+          std::cout << std::endl
+                    << "Push current_vertex's edge onto q2." << std::endl;
+        }
+
+        q2.push(e);
+      }
+
+      // TYPE 2: current_vertex is (1) a first vertex of some edge
+      // other than active_edge, and (2) that edge should not become
+      // the next active_edge.  This happens, e.g., if that edge is
+      //(rangewise) in back along the current bearing.
+      if (k_range < current_vertex.range()) {
+
+        if (PRINTING_DEBUG_DATA) {
+          std::cout << std::endl
+                    << "\E[36m"
+                    << "TYPE 2:"
+                    << "\x1b[0m"
+                    << " current_vertex is" << std::endl
+                    << "(1) a first vertex of some edge "
+                       "other than active_edge, and"
+                    << std::endl
+                    << "(2) that edge should not become "
+                    << "the next active_edge." << std::endl;
+        }
+
+      } // Close Type 2.
+
+      // TYPE 3: current_vertex is (1) the first vertex of some edge
+      // other than active_edge, and (2) that edge should become the
+      // next active_edge.  This happens, e.g., if that edge is
+      //(rangewise) in front along the current bearing.
+      if (k_range >= current_vertex.range()) {
+
+        if (PRINTING_DEBUG_DATA) {
+          std::cout << std::endl
+                    << "\E[36m"
+                    << "TYPE 3:"
+                    << "\x1b[0m"
+                    << " current_vertex is" << std::endl
+                    << "(1) the first vertex of some edge "
+                       "other than active edge, and"
+                    << std::endl
+                    << "(2) that edge should become "
+                    << "the next active_edge." << std::endl;
+        }
+
+        // Push k onto the visibility polygon unless effectively
+        // contiguous with current_vertex.
+        if (xing.size() > 0
+            // and k == k
+            and k_range != INFINITY and
+            distance(k, current_vertex) > epsilon and
+            distance(active_edge->first, observer) > epsilon) {
+
+          if (PRINTING_DEBUG_DATA) {
+            std::cout << std::endl
+                      << "\E[32m"
+                      << "Add type 3 k-point to visibility polygon."
+                      << "\x1b[0m" << std::endl;
+          }
+
+          // Push k-point onto the visibility polygon.
+          vertices_.push_back(k);
+          chop_spikes_at_back(observer, epsilon);
+        }
+
+        // Push current_vertex onto the visibility polygon.
+        vertices_.push_back(current_vertex);
+        chop_spikes_at_back(observer, epsilon);
+        // Set active_edge to edge of current_vertex.
+        active_edge = e;
+
+        if (PRINTING_DEBUG_DATA) {
+          std::cout << std::endl
+                    << "\E[32m"
+                    << "Add current_vertex to visibility polygon."
+                    << "\x1b[0m" << std::endl
+                    << std::endl
+                    << "Set active_edge to edge of current_vertex."
+                    << std::endl;
+        }
+
+      } // Close Type 3.
+    }
+
+    if (PRINTING_DEBUG_DATA) {
+      std::cout << std::endl
+                << "visibility polygon vertices so far are \n"
+                << Polygon(vertices_) << std::endl
+                << std::endl;
+    }
+  } //
+    //
+  //-------END MAIN LOOP-------//
+
+  // The Visibility_Polygon should have a minimal representation
+  chop_spikes_at_wrap_around(observer, epsilon);
+  eliminate_redundant_vertices(epsilon);
+  chop_spikes(observer, epsilon);
+  enforce_standard_form();
+
+  if (PRINTING_DEBUG_DATA) {
+    std::cout << std::endl
+              << "Final visibility polygon vertices are \n"
+              << Polygon(vertices_) << std::endl
+              << std::endl;
+  }
+}
+Visibility_Polygon::Visibility_Polygon(const Point &observer,
+                                       const Polygon &polygon_temp,
+                                       double epsilon) {
+  *this = Visibility_Polygon(observer, Environment(polygon_temp), epsilon);
+}
+
+// Visibility_Graph
+
+Visibility_Graph::Visibility_Graph(const Visibility_Graph &vg2) {
+  n_ = vg2.n_;
+  vertex_counts_ = vg2.vertex_counts_;
+
+  // Allocate adjacency matrix
+  adjacency_matrix_ = new bool *[n_];
+  adjacency_matrix_[0] = new bool[n_ * n_];
+  for (unsigned i = 1; i < n_; i++)
+    adjacency_matrix_[i] = adjacency_matrix_[i - 1] + n_;
+
+  // copy each entry
+  for (unsigned i = 0; i < n_; i++) {
+    for (unsigned j = 0; j < n_; j++) {
+      adjacency_matrix_[i][j] = vg2.adjacency_matrix_[i][j];
+    }
+  }
+}
+
+Visibility_Graph::Visibility_Graph(const Environment &environment,
+                                   double epsilon) {
+  n_ = environment.n();
+
+  // fill vertex_counts_
+  vertex_counts_.reserve(environment.h());
+  for (unsigned i = 0; i < environment.h(); i++)
+    vertex_counts_.push_back(environment[i].n());
+
+  // allocate a contiguous chunk of memory for adjacency_matrix_
+  adjacency_matrix_ = new bool *[n_];
+  adjacency_matrix_[0] = new bool[n_ * n_];
+  for (unsigned i = 1; i < n_; i++)
+    adjacency_matrix_[i] = adjacency_matrix_[i - 1] + n_;
+
+  // fill adjacency matrix by checking for inclusion in the
+  // visibility polygons
+  Polygon polygon_temp;
+  for (unsigned k1 = 0; k1 < n_; k1++) {
+    polygon_temp = Visibility_Polygon(environment(k1), environment, epsilon);
+    for (unsigned k2 = 0; k2 < n_; k2++) {
+      if (k1 == k2)
+        adjacency_matrix_[k1][k1] = true;
+      else
+        adjacency_matrix_[k1][k2] = adjacency_matrix_[k2][k1] =
+            environment(k2).in(polygon_temp, epsilon);
+    }
+  }
+}
+
+Visibility_Graph::Visibility_Graph(const std::vector<Point> points,
+                                   const Environment &environment,
+                                   double epsilon) {
+  n_ = points.size();
+
+  // fill vertex_counts_
+  vertex_counts_.push_back(n_);
+
+  // allocate a contiguous chunk of memory for adjacency_matrix_
+  adjacency_matrix_ = new bool *[n_];
+  adjacency_matrix_[0] = new bool[n_ * n_];
+  for (unsigned i = 1; i < n_; i++)
+    adjacency_matrix_[i] = adjacency_matrix_[i - 1] + n_;
+
+  // fill adjacency matrix by checking for inclusion in the
+  // visibility polygons
+  Polygon polygon_temp;
+  for (unsigned k1 = 0; k1 < n_; k1++) {
+    polygon_temp = Visibility_Polygon(points[k1], environment, epsilon);
+    for (unsigned k2 = 0; k2 < n_; k2++) {
+      if (k1 == k2)
+        adjacency_matrix_[k1][k1] = true;
+      else
+        adjacency_matrix_[k1][k2] = adjacency_matrix_[k2][k1] =
+            points[k2].in(polygon_temp, epsilon);
+    }
+  }
+}
+
+Visibility_Graph::Visibility_Graph(const Guards &guards,
+                                   const Environment &environment,
+                                   double epsilon) {
+  *this = Visibility_Graph(guards.positions_, environment, epsilon);
+}
+
+bool Visibility_Graph::operator()(unsigned i1, unsigned j1, unsigned i2,
+                                  unsigned j2) const {
+  return adjacency_matrix_[two_to_one(i1, j1)][two_to_one(i2, j2)];
+}
+bool Visibility_Graph::operator()(unsigned k1, unsigned k2) const {
+  return adjacency_matrix_[k1][k2];
+}
+bool &Visibility_Graph::operator()(unsigned i1, unsigned j1, unsigned i2,
+                                   unsigned j2) {
+  return adjacency_matrix_[two_to_one(i1, j1)][two_to_one(i2, j2)];
+}
+bool &Visibility_Graph::operator()(unsigned k1, unsigned k2) {
+  return adjacency_matrix_[k1][k2];
+}
+
+Visibility_Graph &
+Visibility_Graph::operator=(const Visibility_Graph &visibility_graph_temp) {
+  if (this == &visibility_graph_temp)
+    return *this;
+
+  n_ = visibility_graph_temp.n_;
+  vertex_counts_ = visibility_graph_temp.vertex_counts_;
+
+  // resize adjacency_matrix_
+  if (adjacency_matrix_ != NULL) {
+    delete[] adjacency_matrix_[0];
+    delete[] adjacency_matrix_;
+  }
+  adjacency_matrix_ = new bool *[n_];
+  adjacency_matrix_[0] = new bool[n_ * n_];
+  for (unsigned i = 1; i < n_; i++)
+    adjacency_matrix_[i] = adjacency_matrix_[i - 1] + n_;
+
+  // copy each entry
+  for (unsigned i = 0; i < n_; i++) {
+    for (unsigned j = 0; j < n_; j++) {
+      adjacency_matrix_[i][j] = visibility_graph_temp.adjacency_matrix_[i][j];
+    }
+  }
+
+  return *this;
+}
+
+unsigned Visibility_Graph::two_to_one(unsigned i, unsigned j) const {
+  unsigned k = 0;
+
+  for (unsigned counter = 0; counter < i; counter++)
+    k += vertex_counts_[counter];
+  k += j;
+
+  return k;
+}
+
+Visibility_Graph::~Visibility_Graph() {
+  if (adjacency_matrix_ != NULL) {
+    delete[] adjacency_matrix_[0];
+    delete[] adjacency_matrix_;
+  }
+}
+
+std::ostream &operator<<(std::ostream &outs,
+                         const Visibility_Graph &visibility_graph) {
+  for (unsigned k1 = 0; k1 < visibility_graph.n(); k1++) {
+    for (unsigned k2 = 0; k2 < visibility_graph.n(); k2++) {
+      outs << visibility_graph(k1, k2);
+      if (k2 < visibility_graph.n() - 1)
+        outs << "  ";
+      else
+        outs << std::endl;
+    }
+  }
+
+  return outs;
+}
+
+} // namespace VisiLibity

--- a/src/visilibity.hpp
+++ b/src/visilibity.hpp
@@ -33,10 +33,8 @@ License along with VisiLibity.  If not, see <http://www.gnu.org/licenses/>.
  * <a href="../VisiLibity.coding_standards.html">Coding Standards</a>
  * <hr>
  * \section release_notes Release Notes
- * <b>Current Functionality</b> in planar polygonal environments with polygonal holes:
- *   <ul>
- *      <li>visibility polygons</li>
- *      <li>visibility graphs</li>
+ * <b>Current Functionality</b> in planar polygonal environments with polygonal
+ * holes: <ul> <li>visibility polygons</li> <li>visibility graphs</li>
  *      <li>Euclidean shortest paths for a point</li>
  *   </ul>
  */
@@ -44,9 +42,8 @@ License along with VisiLibity.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef VISILIBITY_H
 #define VISILIBITY_H
 
-
-//Uncomment these lines when compiling under
-//Microsoft Visual Studio
+// Uncomment these lines when compiling under
+// Microsoft Visual Studio
 /*
 #include <limits>
 #define NAN std::numeric_limits<double>::quiet_NaN()
@@ -56,2114 +53,2004 @@ License along with VisiLibity.  If not, see <http://www.gnu.org/licenses/>.
 #define or ||
 */
 
-#include <cmath>      //math functions in std namespace
+#include <cmath> //math functions in std namespace
+#include <queue> //queue and priority_queue.
+#include <set>   //priority queues with iteration,
 #include <vector>
-#include <queue>      //queue and priority_queue.
-#include <set>        //priority queues with iteration,
-                      //integrated keys
-#include <list>
-#include <algorithm>  //sorting, min, max, reverse
-#include <cstdlib>    //rand and srand
-#include <ctime>      //Unix time
-#include <fstream>    //file I/O
+// integrated keys
+#include <algorithm> //sorting, min, max, reverse
+#include <cassert>   //assertions
+#include <cstdlib>   //rand and srand
+#include <cstring>   //C-string manipulation
+#include <ctime>     //Unix time
+#include <fstream>   //file I/O
 #include <iostream>
-#include <cstring>    //C-string manipulation
-#include <string>     //string class
-#include <cassert>    //assertions
-
+#include <list>
+#include <string> //string class
 
 /// VisiLibity's sole namespace
-namespace VisiLibity
-{
+namespace VisiLibity {
 
-  //Fwd declaration of all classes and structs serves as index.
-  struct Bounding_Box;
-  class Point;
-  class Line_Segment;
-  class Angle;
-  class Ray;
-  class Polar_Point;
-  class Polyline;
-  class Polygon;
-  class Environment;
-  class Guards;
-  class Visibility_Polygon;
-  class Visibility_Graph;
+// Fwd declaration of all classes and structs serves as index.
+struct Bounding_Box;
+class Point;
+class Line_Segment;
+class Angle;
+class Ray;
+class Polar_Point;
+class Polyline;
+class Polygon;
+class Environment;
+class Guards;
+class Visibility_Polygon;
+class Visibility_Graph;
 
+/** \brief  floating-point display precision.
+ *
+ * This is the default precision with which floating point
+ * numbers are displayed or written to files for classes with a
+ * write_to_file() method.
+ */
+const int FIOS_PRECISION = 10;
 
-  /** \brief  floating-point display precision.
+/** \brief  get a uniform random sample from an (inclusive) interval
+ *          on the real line
+ *
+ * \author  Karl J. Obermeyer
+ * \param lower_bound  lower bound of the real interval
+ * \param upper_bound  upper bound of the real interval
+ * \pre  \a lower_bound <= \a upper_bound
+ * \return  a random sample from a uniform probability distribution
+ * on the real interval [\a lower_bound, \a upper_bound]
+ * \remarks  Uses the Standard Library's rand() function. rand()
+ * should be seeded (only necessary once at the beginning of the
+ * program) using the command
+ * std::srand( std::time( NULL ) ); rand();
+ * \warning  performance degrades as upper_bound - lower_bound
+ * approaches RAND_MAX.
+ */
+double uniform_random_sample(double lower_bound, double upper_bound);
+
+/** \brief  rectangle with sides parallel to the x- and y-axes
+ *
+ * \author  Karl J. Obermeyer
+ * Useful for enclosing other geometric objects.
+ */
+struct Bounding_Box {
+  double x_min, x_max, y_min, y_max;
+};
+
+/// Point in the plane represented by Cartesian coordinates
+class Point {
+public:
+  // Constructors
+  /** \brief  default
    *
-   * This is the default precision with which floating point
-   * numbers are displayed or written to files for classes with a
-   * write_to_file() method.
+   * \remarks Data defaults to NAN so that checking whether the
+   * data are numbers can be used as a precondition in functions.
    */
-  const int FIOS_PRECISION = 10;
-
-
-  /** \brief  get a uniform random sample from an (inclusive) interval
-   *          on the real line
+  Point() : x_(NAN), y_(NAN) {}
+  /// costruct from raw coordinates
+  Point(double x_temp, double y_temp) {
+    x_ = x_temp;
+    y_ = y_temp;
+  }
+  // Accessors
+  /// get x coordinate
+  double x() const { return x_; }
+  /// get y coordinate
+  double y() const { return y_; }
+  /** \brief closest Point on \a line_segment_temp
    *
    * \author  Karl J. Obermeyer
-   * \param lower_bound  lower bound of the real interval
-   * \param upper_bound  upper bound of the real interval
-   * \pre  \a lower_bound <= \a upper_bound
-   * \return  a random sample from a uniform probability distribution
-   * on the real interval [\a lower_bound, \a upper_bound]
-   * \remarks  Uses the Standard Library's rand() function. rand()
-   * should be seeded (only necessary once at the beginning of the
-   * program) using the command
-   * std::srand( std::time( NULL ) ); rand();
-   * \warning  performance degrades as upper_bound - lower_bound
-   * approaches RAND_MAX.
+   * \pre  the calling Point data are numbers
+   *       and \a line_segment_temp is nonempty
+   * \return  the Point on \a line_segment_temp which is the smallest
+   * Euclidean distance from the calling Point
    */
-  double uniform_random_sample(double lower_bound, double upper_bound);
-
-
-  /** \brief  rectangle with sides parallel to the x- and y-axes
+  Point projection_onto(const Line_Segment &line_segment_temp) const;
+  /** \brief closest Point on \a ray_temp
    *
    * \author  Karl J. Obermeyer
-   * Useful for enclosing other geometric objects.
+   * \pre  the calling Point and \a ray_temp data are numbers
+   * \return  the Point on \a ray_temp which is the smallest
+   * Euclidean distance from the calling Point
    */
-  struct Bounding_Box { double x_min, x_max, y_min, y_max; };
-
-
-  /// Point in the plane represented by Cartesian coordinates
-  class Point
-  {
-  public:
-    //Constructors
-    /** \brief  default
-     *
-     * \remarks Data defaults to NAN so that checking whether the
-     * data are numbers can be used as a precondition in functions.
-     */
-    Point() : x_(NAN) , y_(NAN) { }
-    /// costruct from raw coordinates
-    Point(double x_temp, double y_temp)
-    { x_=x_temp; y_=y_temp; }
-    //Accessors
-    /// get x coordinate
-    double x () const { return x_; }
-    /// get y coordinate
-    double y () const { return y_; }
-    /** \brief closest Point on \a line_segment_temp
-     *
-     * \author  Karl J. Obermeyer
-     * \pre  the calling Point data are numbers
-     *       and \a line_segment_temp is nonempty
-     * \return  the Point on \a line_segment_temp which is the smallest
-     * Euclidean distance from the calling Point
-     */
-    Point projection_onto(const Line_Segment& line_segment_temp) const;
-    /** \brief closest Point on \a ray_temp
-     *
-     * \author  Karl J. Obermeyer
-     * \pre  the calling Point and \a ray_temp data are numbers
-     * \return  the Point on \a ray_temp which is the smallest
-     * Euclidean distance from the calling Point
-     */
-    Point projection_onto(const Ray& ray_temp) const;
-    /** \brief  closest Point on \a polyline_temp
-     *
-     * \pre  the calling Point data are numbers and \a polyline_temp
-     * is nonempty
-     * \return  the Point on \a polyline_temp which is the smallest
-     * Euclidean distance from the calling Point
-     */
-    Point projection_onto(const Polyline& polyline_temp) const;
-    /** \brief  closest vertex of \a polygon_temp
-     *
-     * \author  Karl J. Obermeyer
-     * \pre  the calling Point data are numbers and \a polygon_temp
-     * is nonempty
-     * \return  the vertex of \a polygon_temp which is the
-     * smallest Euclidean distance from the calling Point
-     */
-    Point projection_onto_vertices_of(const Polygon& polygon_temp) const;
-    /** \brief  closest vertex of \a environment_temp
-     *
-     * \author  Karl J. Obermeyer
-     * \pre  the calling Point data are numbers and \a environment_temp
-     * is nonempty
-     * \return  the vertex of \a environment_temp which is
-     * the smallest Euclidean distance from the calling Point
-     */
-    Point projection_onto_vertices_of(const Environment&
-				      enviroment_temp) const;
-    /** \brief  closest Point on boundary of \a polygon_temp
-     *
-     * \author  Karl J. Obermeyer
-     * \pre  the calling Point data are numbers and \a polygon_temp
-     * is nonempty
-     * \return  the Point on the boundary of \a polygon_temp which is the
-     * smallest Euclidean distance from the calling Point
-     */
-    Point projection_onto_boundary_of(const Polygon& polygon_temp) const;
-    /** \brief  closest Point on boundary of \a environment_temp
-     *
-     * \author  Karl J. Obermeyer
-     * \pre  the calling Point data are numbers and \a environment_temp
-     * is nonempty
-     * \return  the Point on the boundary of \a environment_temp which is
-     * the smalles Euclidean distance from the calling Point
-     */
-    Point projection_onto_boundary_of(const Environment&
-				      enviroment_temp) const;
-    /** \brief  true iff w/in \a epsilon of boundary of \a polygon_temp
-     *
-     * \author  Karl J. Obermeyer
-     * \pre  the calling Point data are numbers and \a polygon_temp
-     * is nonempty
-     * \return true iff the calling Point is within Euclidean distance
-     * \a epsilon of \a polygon_temp 's boundary
-     * \remarks  O(n) time complexity, where n is the number
-     * of vertices of \a polygon_temp
-     */
-    bool on_boundary_of(const Polygon& polygon_temp,
-			double epsilon=0.0) const;
-    /** \brief  true iff w/in \a epsilon of boundary of \a environment_temp
-     *
-     * \author  Karl J. Obermeyer
-     * \pre  the calling Point data are numbers and \a environment_temp
-     * is nonempty
-     * \return true iff the calling Point is within Euclidean distance
-     * \a epsilon of \a environment_temp 's boundary
-     * \remarks  O(n) time complexity, where n is the number
-     * of vertices of \a environment_temp
-     */
-    bool on_boundary_of(const Environment& environment_temp,
-			double epsilon=0.0) const;
-    /** \brief true iff w/in \a epsilon of \a line_segment_temp
-     *
-     * \author  Karl J. Obermeyer
-     * \pre  the calling Point data are numbers and \a line_segment_temp
-     * is nonempty
-     * \return  true iff the calling Point is within distance
-     * \a epsilon of the (closed) Line_Segment \a line_segment_temp
-     */
-    bool in(const Line_Segment& line_segment_temp,
-	    double epsilon=0.0) const;
-    /** \brief true iff w/in \a epsilon of interior but greater than
-     *         \a espilon away from endpoints of \a line_segment_temp
-     *
-     * \author  Karl J. Obermeyer
-     * \pre  the calling Point data are numbers and \a line_segment_temp
-     * is nonempty
-     * \return  true iff the calling Point is within distance \a
-     * epsilon of \line_segment_temp, but distance (strictly) greater
-     * than epsilon from \a line_segment_temp 's endpoints.
-     */
-    bool in_relative_interior_of(const Line_Segment& line_segment_temp,
-				 double epsilon=0.0) const;
-    /** \brief  true iff w/in \a epsilon of \a polygon_temp
-     *
-     * \author  Karl J. Obermeyer
-     *
-     * \pre the calling Point data are numbers and \a polygon_temp is
-     * \a epsilon -simple. Test simplicity with
-     * Polygon::is_simple(epsilon)
-     *
-     * \return  true iff the calling Point is a Euclidean distance no greater
-     * than \a epsilon from the (closed) Polygon (with vertices listed
-     * either cw or ccw) \a polygon_temp.
-     * \remarks  O(n) time complexity, where n is the number of vertices
-     * in \a polygon_temp
-     */
-    bool in(const Polygon& polygon_temp,
-	    double epsilon=0.0) const;
-    /** \brief  true iff w/in \a epsilon of \a environment_temp
-     *
-     * \author  Karl J. Obermeyer
-     *
-     * \pre the calling Point data are numbers and \a environment_temp
-     * is nonempty and \a epsilon -valid. Test validity with
-     * Enviroment::is_valid(epsilon)
-     *
-     * \return  true iff the calling Point is a Euclidean distance no greater
-     * than \a epsilon from the in the (closed) Environment \a environment_temp
-     * \remarks  O(n) time complexity, where n is the number of
-     * vertices in \a environment_temp
-     */
-    bool in(const Environment& environment_temp,
-	    double epsilon=0.0) const;
-    /** \brief  true iff w/in \a epsilon of some endpoint
-     *          of \a line_segment_temp
-     *
-     * \pre  the calling Point data are numbers and \a line_segment_temp
-     * is nonempty
-     * \return  true iff calling Point is a Euclidean distance no greater
-     * than \a epsilon from some endpoint of \a line_segment_temp
-     */
-    bool is_endpoint_of(const Line_Segment& line_segment_temp,
-			double epsilon=0.0) const;
-    //Mutators
-    /// change x coordinate
-    void set_x(double x_temp) { x_ = x_temp;}
-    /// change y coordinate
-    void set_y(double y_temp) { y_ = y_temp;}
-    /** \brief relocate to closest vertex if w/in \a epsilon of some
-     *         vertex (of \a polygon_temp)
-     *
-     * \author  Karl J. Obermeyer
-     * \pre  the calling Point data are numbers and \a polygon_temp
-     * is nonempty
-     * \post If the calling Point was a Euclidean distance no greater
-     * than \a epsilon from any vertex of \a polygon_temp, then it
-     * will be repositioned to coincide with the closest such vertex
-     * \remarks O(n) time complexity, where n is the number of
-     * vertices in \a polygon_temp.
-     */
-    void snap_to_vertices_of(const Polygon& polygon_temp,
-			     double epsilon=0.0);
-    /** \brief relocate to closest vertex if w/in \a epsilon of some
-     *         vertex (of \a environment_temp)
-     *
-     * \author  Karl J. Obermeyer
-     * \pre  the calling Point data are numbers and \a environment_temp
-     * is nonempty
-     * \post If the calling Point was a Euclidean distance no greater
-     * than \a epsilon from any vertex of \a environment_temp, then it
-     * will be repositioned to coincide with the closest such vertex
-     * \remarks O(n) time complexity, where n is the number of
-     * vertices in \a environment_temp.
-     */
-    void snap_to_vertices_of(const Environment& environment_temp,
-			     double epsilon=0.0);
-    /** \brief relocate to closest Point on boundary if w/in \a epsilon
-     *	       of the boundary (of \a polygon_temp)
-     *
-     * \author  Karl J. Obermeyer
-     * \pre  the calling Point data are numbers and \a polygon_temp
-     * is nonempty
-     * \post if the calling Point was a Euclidean distance no greater
-     * than \a epsilon from the boundary of \a polygon_temp, then it
-     * will be repositioned to it's projection onto that boundary
-     * \remarks O(n) time complexity, where n is the number of
-     * vertices in \a polygon_temp.
-     */
-    void snap_to_boundary_of(const Polygon& polygon_temp,
-			     double epsilon=0.0);
-    /** \brief relocate to closest Point on boundary if w/in \a epsilon
-     *	       of the boundary (of \a environment_temp)
-     *
-     * \author  Karl J. Obermeyer
-     * \pre  the calling Point data are numbers and \a environment_temp
-     * is nonempty
-     * \post if the calling Point was a Euclidean distance no greater
-     * than \a epsilon from the boundary of \a environment_temp, then it
-     * will be repositioned to it's projection onto that boundary
-     * \remarks O(n) time complexity, where n is the number of
-     * vertices in \a environment_temp.
-     */
-    void snap_to_boundary_of(const Environment& environment_temp,
-			     double epsilon=0.0);
-  protected:
-    double x_;
-    double y_;
-  };
-
-
-  /** \brief True iff Points' coordinates are identical.
+  Point projection_onto(const Ray &ray_temp) const;
+  /** \brief  closest Point on \a polyline_temp
    *
-   * \remarks  NAN==NAN returns false, so if either point has
-   * not been assigned real number coordinates, they will not be ==
+   * \pre  the calling Point data are numbers and \a polyline_temp
+   * is nonempty
+   * \return  the Point on \a polyline_temp which is the smallest
+   * Euclidean distance from the calling Point
    */
-  bool  operator == (const Point& point1, const Point& point2);
-  /// True iff Points' coordinates are not identical.
-  bool  operator != (const Point& point1, const Point& point2);
-
-
-  /** \brief  compare lexicographic order of points
+  Point projection_onto(const Polyline &polyline_temp) const;
+  /** \brief  closest vertex of \a polygon_temp
    *
-   * For Points p1 and p2, p1 < p2 iff either p1.x() < p2.x() or
-   * p1.x()==p2.x() and p1.y()<p2.y().  False if any member data have
-   * not been assigned (numbers).
+   * \author  Karl J. Obermeyer
+   * \pre  the calling Point data are numbers and \a polygon_temp
+   * is nonempty
+   * \return  the vertex of \a polygon_temp which is the
+   * smallest Euclidean distance from the calling Point
+   */
+  Point projection_onto_vertices_of(const Polygon &polygon_temp) const;
+  /** \brief  closest vertex of \a environment_temp
+   *
+   * \author  Karl J. Obermeyer
+   * \pre  the calling Point data are numbers and \a environment_temp
+   * is nonempty
+   * \return  the vertex of \a environment_temp which is
+   * the smallest Euclidean distance from the calling Point
+   */
+  Point projection_onto_vertices_of(const Environment &enviroment_temp) const;
+  /** \brief  closest Point on boundary of \a polygon_temp
+   *
+   * \author  Karl J. Obermeyer
+   * \pre  the calling Point data are numbers and \a polygon_temp
+   * is nonempty
+   * \return  the Point on the boundary of \a polygon_temp which is the
+   * smallest Euclidean distance from the calling Point
+   */
+  Point projection_onto_boundary_of(const Polygon &polygon_temp) const;
+  /** \brief  closest Point on boundary of \a environment_temp
+   *
+   * \author  Karl J. Obermeyer
+   * \pre  the calling Point data are numbers and \a environment_temp
+   * is nonempty
+   * \return  the Point on the boundary of \a environment_temp which is
+   * the smalles Euclidean distance from the calling Point
+   */
+  Point projection_onto_boundary_of(const Environment &enviroment_temp) const;
+  /** \brief  true iff w/in \a epsilon of boundary of \a polygon_temp
+   *
+   * \author  Karl J. Obermeyer
+   * \pre  the calling Point data are numbers and \a polygon_temp
+   * is nonempty
+   * \return true iff the calling Point is within Euclidean distance
+   * \a epsilon of \a polygon_temp 's boundary
+   * \remarks  O(n) time complexity, where n is the number
+   * of vertices of \a polygon_temp
+   */
+  bool on_boundary_of(const Polygon &polygon_temp, double epsilon = 0.0) const;
+  /** \brief  true iff w/in \a epsilon of boundary of \a environment_temp
+   *
+   * \author  Karl J. Obermeyer
+   * \pre  the calling Point data are numbers and \a environment_temp
+   * is nonempty
+   * \return true iff the calling Point is within Euclidean distance
+   * \a epsilon of \a environment_temp 's boundary
+   * \remarks  O(n) time complexity, where n is the number
+   * of vertices of \a environment_temp
+   */
+  bool on_boundary_of(const Environment &environment_temp,
+                      double epsilon = 0.0) const;
+  /** \brief true iff w/in \a epsilon of \a line_segment_temp
+   *
+   * \author  Karl J. Obermeyer
+   * \pre  the calling Point data are numbers and \a line_segment_temp
+   * is nonempty
+   * \return  true iff the calling Point is within distance
+   * \a epsilon of the (closed) Line_Segment \a line_segment_temp
+   */
+  bool in(const Line_Segment &line_segment_temp, double epsilon = 0.0) const;
+  /** \brief true iff w/in \a epsilon of interior but greater than
+   *         \a espilon away from endpoints of \a line_segment_temp
+   *
+   * \author  Karl J. Obermeyer
+   * \pre  the calling Point data are numbers and \a line_segment_temp
+   * is nonempty
+   * \return  true iff the calling Point is within distance \a
+   * epsilon of \line_segment_temp, but distance (strictly) greater
+   * than epsilon from \a line_segment_temp 's endpoints.
+   */
+  bool in_relative_interior_of(const Line_Segment &line_segment_temp,
+                               double epsilon = 0.0) const;
+  /** \brief  true iff w/in \a epsilon of \a polygon_temp
+   *
+   * \author  Karl J. Obermeyer
+   *
+   * \pre the calling Point data are numbers and \a polygon_temp is
+   * \a epsilon -simple. Test simplicity with
+   * Polygon::is_simple(epsilon)
+   *
+   * \return  true iff the calling Point is a Euclidean distance no greater
+   * than \a epsilon from the (closed) Polygon (with vertices listed
+   * either cw or ccw) \a polygon_temp.
+   * \remarks  O(n) time complexity, where n is the number of vertices
+   * in \a polygon_temp
+   */
+  bool in(const Polygon &polygon_temp, double epsilon = 0.0) const;
+  /** \brief  true iff w/in \a epsilon of \a environment_temp
+   *
+   * \author  Karl J. Obermeyer
+   *
+   * \pre the calling Point data are numbers and \a environment_temp
+   * is nonempty and \a epsilon -valid. Test validity with
+   * Enviroment::is_valid(epsilon)
+   *
+   * \return  true iff the calling Point is a Euclidean distance no greater
+   * than \a epsilon from the in the (closed) Environment \a environment_temp
+   * \remarks  O(n) time complexity, where n is the number of
+   * vertices in \a environment_temp
+   */
+  bool in(const Environment &environment_temp, double epsilon = 0.0) const;
+  /** \brief  true iff w/in \a epsilon of some endpoint
+   *          of \a line_segment_temp
+   *
+   * \pre  the calling Point data are numbers and \a line_segment_temp
+   * is nonempty
+   * \return  true iff calling Point is a Euclidean distance no greater
+   * than \a epsilon from some endpoint of \a line_segment_temp
+   */
+  bool is_endpoint_of(const Line_Segment &line_segment_temp,
+                      double epsilon = 0.0) const;
+  // Mutators
+  /// change x coordinate
+  void set_x(double x_temp) { x_ = x_temp; }
+  /// change y coordinate
+  void set_y(double y_temp) { y_ = y_temp; }
+  /** \brief relocate to closest vertex if w/in \a epsilon of some
+   *         vertex (of \a polygon_temp)
+   *
+   * \author  Karl J. Obermeyer
+   * \pre  the calling Point data are numbers and \a polygon_temp
+   * is nonempty
+   * \post If the calling Point was a Euclidean distance no greater
+   * than \a epsilon from any vertex of \a polygon_temp, then it
+   * will be repositioned to coincide with the closest such vertex
+   * \remarks O(n) time complexity, where n is the number of
+   * vertices in \a polygon_temp.
+   */
+  void snap_to_vertices_of(const Polygon &polygon_temp, double epsilon = 0.0);
+  /** \brief relocate to closest vertex if w/in \a epsilon of some
+   *         vertex (of \a environment_temp)
+   *
+   * \author  Karl J. Obermeyer
+   * \pre  the calling Point data are numbers and \a environment_temp
+   * is nonempty
+   * \post If the calling Point was a Euclidean distance no greater
+   * than \a epsilon from any vertex of \a environment_temp, then it
+   * will be repositioned to coincide with the closest such vertex
+   * \remarks O(n) time complexity, where n is the number of
+   * vertices in \a environment_temp.
+   */
+  void snap_to_vertices_of(const Environment &environment_temp,
+                           double epsilon = 0.0);
+  /** \brief relocate to closest Point on boundary if w/in \a epsilon
+   *	       of the boundary (of \a polygon_temp)
+   *
+   * \author  Karl J. Obermeyer
+   * \pre  the calling Point data are numbers and \a polygon_temp
+   * is nonempty
+   * \post if the calling Point was a Euclidean distance no greater
+   * than \a epsilon from the boundary of \a polygon_temp, then it
+   * will be repositioned to it's projection onto that boundary
+   * \remarks O(n) time complexity, where n is the number of
+   * vertices in \a polygon_temp.
+   */
+  void snap_to_boundary_of(const Polygon &polygon_temp, double epsilon = 0.0);
+  /** \brief relocate to closest Point on boundary if w/in \a epsilon
+   *	       of the boundary (of \a environment_temp)
+   *
+   * \author  Karl J. Obermeyer
+   * \pre  the calling Point data are numbers and \a environment_temp
+   * is nonempty
+   * \post if the calling Point was a Euclidean distance no greater
+   * than \a epsilon from the boundary of \a environment_temp, then it
+   * will be repositioned to it's projection onto that boundary
+   * \remarks O(n) time complexity, where n is the number of
+   * vertices in \a environment_temp.
+   */
+  void snap_to_boundary_of(const Environment &environment_temp,
+                           double epsilon = 0.0);
+
+protected:
+  double x_;
+  double y_;
+};
+
+/** \brief True iff Points' coordinates are identical.
+ *
+ * \remarks  NAN==NAN returns false, so if either point has
+ * not been assigned real number coordinates, they will not be ==
+ */
+bool operator==(const Point &point1, const Point &point2);
+/// True iff Points' coordinates are not identical.
+bool operator!=(const Point &point1, const Point &point2);
+
+/** \brief  compare lexicographic order of points
+ *
+ * For Points p1 and p2, p1 < p2 iff either p1.x() < p2.x() or
+ * p1.x()==p2.x() and p1.y()<p2.y().  False if any member data have
+ * not been assigned (numbers).
+ * \remarks  lex. comparison is very sensitive to perturbations if
+ * two Points nearly define a line parallel to one of the axes
+ */
+bool operator<(const Point &point1, const Point &point2);
+/** \brief  compare lexicographic order of points
+ *
+ * For Points p1 and p2, p1 < p2 iff either p1.x() < p2.x() or
+ * p1.x()==p2.x() and p1.y()<p2.y().  False if any member data have
+ * not been assigned (numbers).
+ * \remarks  lex. comparison is very sensitive to perturbations if
+ * two Points nearly define a line parallel to one of the axes
+ */
+bool operator>(const Point &point1, const Point &point2);
+/** \brief  compare lexicographic order of points
+ *
+ * For Points p1 and p2, p1 < p2 iff either p1.x() < p2.x() or
+ * p1.x()==p2.x() and p1.y()<p2.y().  False if any member data have
+ * not been assigned (numbers).
+ * \remarks  lex. comparison is very sensitive to perturbations if
+ * two Points nearly define a line parallel to one of the axes
+ */
+bool operator>=(const Point &point1, const Point &point2);
+/** \brief  compare lexicographic order of points
+ *
+ * For Points p1 and p2, p1 < p2 iff either p1.x() < p2.x() or
+ * p1.x()==p2.x() and p1.y()<p2.y().  False if any member data have
+ * not been assigned (numbers).
+ * \remarks  lex. comparison is very sensitive to perturbations if
+ * two Points nearly define a line parallel to one of the axes
+ */
+bool operator<=(const Point &point1, const Point &point2);
+
+/// vector addition of Points
+Point operator+(const Point &point1, const Point &point2);
+/// vector subtraction of Points
+Point operator-(const Point &point1, const Point &point2);
+
+//// dot (scalar) product treats the Points as vectors
+Point operator*(const Point &point1, const Point &point2);
+
+/// simple scaling treats the Point as a vector
+Point operator*(double scalar, const Point &point2);
+/// simple scaling treats the Point as a vector
+Point operator*(const Point &point1, double scalar);
+
+/** \brief  cross product (signed) magnitude treats the Points as vectors
+ *
+ * \author  Karl J. Obermeyer
+ * \pre  Points' data are numbers
+ * \remarks This is equal to the (signed) area of the parallelogram created
+ * by the Points viewed as vectors.
+ */
+double cross(const Point &point1, const Point &point2);
+
+/** \brief  Euclidean distance between Points
+ *
+ * \pre  Points' data are numbers
+ */
+double distance(const Point &point1, const Point &point2);
+
+/** \brief  Euclidean distance between a Point and a Line_Segment
+ *
+ * \author  Karl J. Obermeyer
+ * \pre  Point's data are numbers and the Line_Segment is nonempty
+ */
+double distance(const Point &point_temp, const Line_Segment &line_segment_temp);
+/** \brief  Euclidean distance between a Point and a Line_Segment
+ *
+ * \author  Karl J. Obermeyer
+ * \pre  Point's data are numbers and the Line_Segment is nonempty
+ */
+double distance(const Line_Segment &line_segment_temp, const Point &point_temp);
+
+/** \brief  Euclidean distance between a Point and a Ray
+ *
+ * \author  Karl J. Obermeyer
+ * \pre  Point's and Ray's data are numbers
+ */
+double distance(const Point &point_temp, const Ray &ray_temp);
+/** \brief  Euclidean distance between a Point and a Ray
+ *
+ * \author  Karl J. Obermeyer
+ * \pre  Point's and Ray's data are numbers
+ */
+double distance(const Ray &ray_temp, const Point &point_temp);
+
+/** \brief  Euclidean distance between a Point and a Polyline
+ *
+ * \author  Karl J. Obermeyer
+ * \pre  Point's data are numbers and the Polyline is nonempty
+ */
+double distance(const Point &point_temp, const Polyline &polyline_temp);
+/** \brief  Euclidean distance between a Point and a Polyline
+ *
+ * \author  Karl J. Obermeyer
+ * \pre  Point's data are numbers and the Polyline is nonempty
+ */
+double distance(const Polyline &polyline_temp, const Point &point_temp);
+
+/** \brief  Euclidean distance between a Point and a Polygon's boundary
+ *
+ * \author  Karl J. Obermeyer
+ * \pre  Point's data are numbers and the Polygon is nonempty
+ */
+double boundary_distance(const Point &point_temp, const Polygon &polygon_temp);
+/** \brief  Euclidean distance between a Point and a Polygon's boundary
+ *
+ * \author  Karl J. Obermeyer
+ * \pre  Point's data are numbers and the Polygon is nonempty
+ */
+double boundary_distance(const Polygon &polygon_temp, const Point &point_temp);
+
+/** \brief  Euclidean distance between a Point and a Environment's boundary
+ *
+ * \author  Karl J. Obermeyer
+ * \pre  Point's data are numbers and the Environment is nonempty
+ */
+double boundary_distance(const Point &point_temp,
+                         const Environment &environment_temp);
+/** \brief  Euclidean distance between a Point and a Environment's boundary
+ *
+ * \author  Karl J. Obermeyer
+ * \pre  Point's data are numbers and the Environment is nonempty
+ */
+double boundary_distance(const Environment &environment_temp,
+                         const Point &point_temp);
+
+/// print a Point
+std::ostream &operator<<(std::ostream &outs, const Point &point_temp);
+
+/** \brief line segment in the plane represented by its endpoints
+ *
+ * Closed and oriented line segment in the plane represented by its endpoints.
+ * \remarks  may be degenerate (colocated endpoints) or empty
+ */
+class Line_Segment {
+public:
+  // Constructors
+  /// default to empty
+  Line_Segment();
+  /// copy constructor
+  Line_Segment(const Line_Segment &line_segment_temp);
+  /// construct degenerate segment from a single Point
+  Line_Segment(const Point &point_temp);
+  /// Line_Segment pointing from first_point_temp to second_point_temp
+  Line_Segment(const Point &first_point_temp, const Point &second_point_temp,
+               double epsilon = 0);
+  // Accessors
+  /** \brief  first endpoint
+   *
+   * \pre size() > 0
+   * \return  the first Point of the Line_Segment
+   * \remarks  If size() == 1, then both first() and second() are valid
+   * and will return the same Point
+   */
+  Point first() const;
+  /** \brief  second endpoint
+   *
+   * \pre size() > 0
+   * \return  the second Point of the Line_Segment
+   * \remarks  If size() == 1, then both first() and second() are valid
+   * and will return the same Point
+   */
+  Point second() const;
+  /** \brief  number of distinct endpoints
+   *
+   * \remarks
+   * size 0 => empty line segment;
+   * size 1 => degenerate (single point) line segment;
+   * size 2 => full-fledged (bona fide) line segment
+   */
+  unsigned size() const { return size_; }
+  /** \brief midpoint
+   *
+   * \pre size() > 0
+   */
+  Point midpoint() const;
+  /** \brief Euclidean length
+   *
+   * \pre size() > 0
+   */
+  double length() const;
+  /** \brief  true iff vertices in lex. order
+   *
+   * \pre  size() > 0
+   * \return  true iff vertices are listed beginning with the vertex
+   * which is lexicographically smallest (lowest x, then lowest y)
    * \remarks  lex. comparison is very sensitive to perturbations if
    * two Points nearly define a line parallel to one of the axes
    */
-  bool  operator <  (const Point& point1, const Point& point2);
-  /** \brief  compare lexicographic order of points
+  bool is_in_standard_form() const;
+  // Mutators
+  /// assignment operator
+  Line_Segment &operator=(const Line_Segment &line_segment_temp);
+  /** \brief set first endpoint
    *
-   * For Points p1 and p2, p1 < p2 iff either p1.x() < p2.x() or
-   * p1.x()==p2.x() and p1.y()<p2.y().  False if any member data have
-   * not been assigned (numbers).
+   * \remarks  if \a point_temp is w/in a distance \a epsilon of an existing
+   * endpoint, the coordinates of \a point_temp are used and size is set to
+   * 1 as appropriate
+   */
+  void set_first(const Point &point_temp, double epsilon = 0.0);
+  /** \brief set second endpoint
+   *
+   * \remarks  if \a point_temp is w/in a distance \a epsilon of an existing
+   * endpoint, the coordinates of \a point_temp are used and size is set to
+   * 1 as appropriate
+   */
+  void set_second(const Point &point_temp, double epsilon = 0.0);
+  /** \brief  reverse order of endpoints
+   *
+   * \post order of endpoints is reversed.
+   */
+  void reverse();
+  /** \brief  enforce that lex. smallest endpoint first
+   *
+   * \post the lexicographically smallest endpoint (lowest x, then lowest y)
+   * is first
    * \remarks  lex. comparison is very sensitive to perturbations if
    * two Points nearly define a line parallel to one of the axes
    */
-  bool  operator >  (const Point& point1, const Point& point2);
-  /** \brief  compare lexicographic order of points
+  void enforce_standard_form();
+  /// erase both endpoints and set line segment empty (size 0)
+  void clear();
+  /// destructor
+  virtual ~Line_Segment();
+
+protected:
+  // Pointer to dynamic array of endpoints.
+  Point *endpoints_;
+  // See size() comments.
+  unsigned size_;
+};
+
+/** \brief  true iff endpoint coordinates are exactly equal, but
+ *          false if either Line_Segment has size 0
+ *
+ * \remarks  respects ordering of vertices, i.e., even if the line segments
+ * overlap exactly, they are not considered == unless the orientations are
+ * the same
+ */
+bool operator==(const Line_Segment &line_segment1,
+                const Line_Segment &line_segment2);
+/// true iff endpoint coordinates are not ==
+bool operator!=(const Line_Segment &line_segment1,
+                const Line_Segment &line_segment2);
+
+/** \brief  true iff line segments' endpoints match up w/in a (closed)
+ *          \a epsilon ball of each other, but false if either
+ *          Line_Segment has size 0
+ *
+ * \author  Karl J. Obermeyer
+ * \remarks  this function will return true even if it has to flip
+ * the orientation of one of the segments to get the vertices to
+ * match up
+ */
+bool equivalent(Line_Segment line_segment1, Line_Segment line_segment2,
+                double epsilon = 0);
+
+/** \brief  Euclidean distance between Line_Segments
+ *
+ * \author  Karl J. Obermeyer
+ * \pre  \a line_segment1.size() > 0 and \a line_segment2.size() > 0
+ */
+double distance(const Line_Segment &line_segment1,
+                const Line_Segment &line_segment2);
+
+/** \brief  Euclidean distance between a Line_Segment and the
+ *          boundary of a Polygon
+ *
+ * \author  Karl J. Obermeyer
+ * \pre  \a line_segment.size() > 0 and \a polygon.n() > 0
+ */
+double boundary_distance(const Line_Segment &line_segment,
+                         const Polygon &polygon);
+
+/** \brief  Euclidean distance between a Line_Segment and the
+ *          boundary of a Polygon
+ *
+ * \author  Karl J. Obermeyer
+ * \pre  \a line_segment.size() > 0 and \a polygon.n() > 0
+ */
+double boundary_distance(const Polygon &polygon,
+                         const Line_Segment &line_segment);
+
+/** \brief  true iff the Euclidean distance between Line_Segments is
+ *          no greater than \a epsilon, false if either line segment
+ *          has size 0
+ *
+ * \author  Karl J. Obermeyer
+ */
+bool intersect(const Line_Segment &line_segment1,
+               const Line_Segment &line_segment2, double epsilon = 0.0);
+
+/** \brief  true iff line segments intersect properly w/in epsilon,
+ *          false if either line segment has size 0
+ *
+ * \author  Karl J. Obermeyer
+ * \return true iff Line_Segments intersect exactly at a single
+ * point in their relative interiors.  For robustness, here the
+ * relative interior of a Line_Segment is consider to be any Point
+ * in the Line_Segment which is a distance greater than \a epsilon
+ * from both endpoints.
+ */
+bool intersect_proper(const Line_Segment &line_segment1,
+                      const Line_Segment &line_segment2, double epsilon = 0.0);
+
+/** \brief  intersection of Line_Segments
+ *
+ * \author  Karl J. Obermeyer
+ * \return a Line_Segment of size 0, 1, or 2
+ * \remarks  size 0 results if the distance (or at least the
+ * floating-point computed distance) between line_segment1 and
+ * line_segment2 is (strictly) greater than epsilon. size 1 results
+ * if the segments intersect poperly, form a T intersection, or --
+ * intersection.  size 2 results when two or more endpoints are a
+ * Euclidean distance no greater than \a epsilon from the opposite
+ * segment, and the overlap of the segments has a length greater
+ * than \a epsilon.
+ */
+Line_Segment intersection(const Line_Segment &line_segment1,
+                          const Line_Segment &line_segment2,
+                          double epsilon = 0.0);
+
+/// print a Line_Segment
+std::ostream &operator<<(std::ostream &outs,
+                         const Line_Segment &line_segment_temp);
+
+/** \brief  angle in radians represented by a value in
+ *          the interval [0,2*M_PI]
+ *
+ * \remarks  the intended interpretation is that angles 0 and 2*M_PI
+ * correspond to the positive x-axis of the coordinate system
+ */
+class Angle {
+public:
+  // Constructors
+  /** \brief  default
    *
-   * For Points p1 and p2, p1 < p2 iff either p1.x() < p2.x() or
-   * p1.x()==p2.x() and p1.y()<p2.y().  False if any member data have
-   * not been assigned (numbers).
+   * \remarks  data defaults to NAN so that checking whether the
+   * data are numbers can be used as a precondition in functions
+   */
+  Angle() : angle_radians_(NAN) {}
+  /// construct from real value, mod into interval [0, 2*M_PI)
+  Angle(double data_temp);
+  /** \brief construct using 4 quadrant inverse tangent into [0, 2*M_PI),
+   *         where 0 points along the x-axis
+   */
+  Angle(double rise_temp, double run_temp);
+  // Accessors
+  /// get radians
+  double get() const { return angle_radians_; }
+  // Mutators
+  /// set angle, mod into interval [0, 2*PI)
+  void set(double data_temp);
+  /** \brief  set angle data to 2*M_PI
+   *
+   * \remarks  sometimes it is necessary to set the angle value to
+   * 2*M_PI instead of 0, so that the lex. inequalities behave
+   * appropriately during a radial line sweep
+   */
+  void set_to_2pi() { angle_radians_ = 2 * M_PI; }
+  /// set to new random angle in [0, 2*M_PI)
+  void randomize();
+
+private:
+  double angle_radians_;
+};
+
+/// compare angle radians
+bool operator==(const Angle &angle1, const Angle &angle2);
+/// compare angle radians
+bool operator!=(const Angle &angle1, const Angle &angle2);
+
+/// compare angle radians
+bool operator>(const Angle &angle1, const Angle &angle2);
+/// compare angle radians
+bool operator<(const Angle &angle1, const Angle &angle2);
+/// compare angle radians
+bool operator>=(const Angle &angle1, const Angle &angle2);
+/// compare angle radians
+bool operator<=(const Angle &angle1, const Angle &angle2);
+
+/// add angles' radians and mod into [0, 2*M_PI)
+Angle operator+(const Angle &angle1, const Angle &angle2);
+/// subtract angles' radians and mod into [0, 2*M_PI)
+Angle operator-(const Angle &angle1, const Angle &angle2);
+
+/** \brief  geodesic distance in radians between Angles
+ *
+ * \author  Karl J. Obermeyer
+ * \pre  \a angle1 and \a angle2 data are numbers
+ */
+double geodesic_distance(const Angle &angle1, const Angle &angle2);
+
+/** \brief  1.0 => geodesic path from angle1 to angle2
+ *          is couterclockwise, -1.0 => clockwise
+ *
+ * \author  Karl J. Obermeyer
+ * \pre  \a angle1 and \a angle2 data are numbers
+ */
+double geodesic_direction(const Angle &angle1, const Angle &angle2);
+
+/// print Angle
+std::ostream &operator<<(std::ostream &outs, const Angle &angle_temp);
+
+/** \brief  Point in the plane packaged together with polar
+ *          coordinates w.r.t. specified origin
+ *
+ * The origin of the polar coordinate system is stored with the
+ * Polar_Point (in \a polar_origin_) and bearing is measured ccw from the
+ * positive x-axis.
+ * \remarks  used, e.g., for radial line sweeps
+ */
+class Polar_Point : public Point {
+public:
+  // Constructors
+  /** \brief  default
+   *
+   * \remarks  Data defaults to NAN so that checking whether the
+   * data are numbers can be used as a precondition in functions.
+   */
+  Polar_Point() : Point(), range_(NAN), bearing_(NAN) {}
+  /** \brief  construct from (Cartesian) Points
+   *
+   * \pre  member data of \a polar_origin_temp and \a point_temp have
+   * been assigned (numbers)
+   * \param polar_origin_temp  the origin of the polar coordinate system
+   * \param point_temp  the point to be represented
+   * \remarks  if polar_origin_temp == point_temp, the default
+   * bearing is Angle(0.0)
+   */
+  Polar_Point(const Point &polar_origin_temp, const Point &point_temp,
+              double epsilon = 0.0);
+  // Accessors
+  /** \brief  origin of the polar coordinate system in which the point is
+   *          represented
+   */
+  Point polar_origin() const { return polar_origin_; }
+  /// Euclidean distance from the point represented to the origin of
+  /// the polar coordinate system
+  double range() const { return range_; }
+  /// bearing from polar origin w.r.t. direction parallel to x-axis
+  Angle bearing() const { return bearing_; }
+  // Mutators
+  /** \brief  set the origin of the polar coordinate system
+   *
+   * \remarks x and y held constant, bearing and range modified
+   * accordingly
+   */
+  void set_polar_origin(const Point &polar_origin_temp);
+  /** \brief  set x
+   *
+   * \remarks  polar_origin held constant, bearing and range modified
+   * accordingly
+   */
+  void set_x(double x_temp);
+  /** \brief  set y
+   *
+   * \remarks  polar_origin held constant, bearing and range modified
+   * accordingly
+   */
+  void set_y(double y_temp);
+  /** \brief set range
+   *
+   * \remarks  polar_origin held constant, x and y modified
+   * accordingly
+   */
+  void set_range(double range_temp);
+  /** \brief set bearing
+   *
+   * \remarks  polar_origin and range held constant, x and y modified
+   * accordingly
+   */
+  void set_bearing(const Angle &bearing_temp);
+  /** \brief  set bearing Angle data to 2*M_PI
+   *
+   * \remarks  Special function for use in computations involving a
+   * radial line sweep; sometimes it is necessary to set the angle
+   * value to 2*PI instead of 0, so that the lex. inequalities
+   * behave appropriately
+   */
+  void set_bearing_to_2pi() { bearing_.set_to_2pi(); }
+
+protected:
+  // Origin of the polar coordinate system in world coordinates.
+  Point polar_origin_;
+  // Polar coordinates where radius always positive, and angle
+  // measured ccw from the world coordinate system's x-axis.
+  double range_;
+  Angle bearing_;
+};
+
+/** \brief  compare member data
+ *
+ * \remarks  returns false if any member data are NaN
+ */
+bool operator==(const Polar_Point &polar_point1,
+                const Polar_Point &polar_point2);
+bool operator!=(const Polar_Point &polar_point1,
+                const Polar_Point &polar_point2);
+
+/** \brief  compare according to polar lexicographic order
+ *          (smaller bearing, then smaller range)
+ *
+ *  false if any member data have not been assigned (numbers)
+ * \remarks  lex. comparison is very sensitive to perturbations if
+ * two Points nearly define a radial line
+ */
+bool operator>(const Polar_Point &polar_point1,
+               const Polar_Point &polar_point2);
+/** \brief  compare according to polar lexicographic order
+ *          (smaller bearing, then smaller range)
+ *
+ *  false if any member data have not been assigned (numbers)
+ * \remarks  lex. comparison is very sensitive to perturbations if
+ * two Points nearly define a radial line
+ */
+bool operator<(const Polar_Point &polar_point1,
+               const Polar_Point &polar_point2);
+/** \brief  compare according to polar lexicographic order
+ *          (smaller bearing, then smaller range)
+ *
+ *  false if any member data have not been assigned (numbers)
+ * \remarks  lex. comparison is very sensitive to perturbations if
+ * two Points nearly define a radial line
+ */
+bool operator>=(const Polar_Point &polar_point1,
+                const Polar_Point &polar_point2);
+/** \brief  compare according to polar lexicographic order
+ *          (smaller bearing, then smaller range)
+ *
+ *  false if any member data have not been assigned (numbers)
+ * \remarks  lex. comparison is very sensitive to perturbations if
+ * two Points nearly define a radial line
+ */
+bool operator<=(const Polar_Point &polar_point1,
+                const Polar_Point &polar_point2);
+
+/// print Polar_Point
+std::ostream &operator<<(std::ostream &outs,
+                         const Polar_Point &polar_point_temp);
+
+/// ray in the plane represented by base Point and bearing Angle
+class Ray {
+public:
+  // Constructors
+  /** \brief  default
+   *
+   * \remarks data defaults to NAN so that checking whether the data
+   * are numbers can be used as a precondition in functions
+   */
+  Ray() {}
+  /// construct ray emanating from \a base_point_temp in the direction
+  /// \a bearing_temp
+  Ray(Point base_point_temp, Angle bearing_temp)
+      : base_point_(base_point_temp), bearing_(bearing_temp) {}
+  /// construct ray emanating from \a base_point_temp towards
+  /// \a bearing_point
+  Ray(Point base_point_temp, Point bearing_point);
+  // Accessors
+  /// get base point
+  Point base_point() const { return base_point_; }
+  /// get bearing
+  Angle bearing() const { return bearing_; }
+  // Mutators
+  /// set base point
+  void set_base_point(const Point &point_temp) { base_point_ = point_temp; }
+  /// set bearing
+  void set_bearing(const Angle &angle_temp) { bearing_ = angle_temp; }
+
+private:
+  Point base_point_;
+  Angle bearing_;
+};
+
+/** \brief  compare member data
+ *
+ * \remarks  returns false if any member data are NaN
+ */
+bool operator==(const Ray &ray1, const Ray &ray2);
+/** \brief  compare member data
+ *
+ * \remarks  negation of ==
+ */
+bool operator!=(const Ray &ray1, const Ray &ray2);
+
+/** \brief compute the intersection of a Line_Segment with a Ray
+ *
+ * \author  Karl J. Obermeyer
+ * \pre  member data of \a ray_temp has been assigned (numbers) and
+ * \a line_segment_temp has size greater than 0
+ * \remarks  as a convention, if the intersection has positive
+ * length, the Line_Segment returned has the first point closest to
+ * the Ray's base point
+ */
+Line_Segment intersection(const Ray ray_temp,
+                          const Line_Segment &line_segment_temp,
+                          double epsilon = 0.0);
+/** \brief compute the intersection of a Line_Segment with a Ray
+ *
+ * \author  Karl J. Obermeyer
+ * \pre  member data of \a ray_temp has been assigned (numbers) and
+ * \a line_segment_temp has size greater than 0
+ * \remarks  as a convention, if the intersection has positive
+ * length, the Line_Segment returned has the first point closest to
+ * the Ray's base point
+ */
+Line_Segment intersection(const Line_Segment &line_segment_temp,
+                          const Ray &ray_temp, double epsilon = 0.0);
+
+/// oriented polyline in the plane represented by list of vertices
+class Polyline {
+public:
+  friend class Point;
+  // Constructors
+  /// default to empty
+  Polyline() {}
+  /// construct from vector of vertices
+  Polyline(const std::vector<Point> &vertices_temp) {
+    vertices_ = vertices_temp;
+  }
+  // Accessors
+  /** \brief  raw access
+   *
+   * \remarks for efficiency, no bounds checks; usually trying to
+   * access out of bounds causes a bus error
+   */
+  Point operator[](unsigned i) const { return vertices_[i]; }
+  /// vertex count
+  unsigned size() const { return vertices_.size(); }
+  /// Euclidean length of the Polyline
+  double length() const;
+  /** \brief  Euclidean diameter
+   *
+   * \pre  Polyline has greater than 0 vertices
+   * \return  the maximum Euclidean distance between all pairs of
+   * vertices
+   * \remarks  time complexity O(n^2), where n is the number of
+   * vertices representing the Polyline
+   */
+  double diameter() const;
+  // a box which fits snugly around the Polyline
+  Bounding_Box bbox() const;
+  // Mutators
+  /** \brief  raw access
+   *
+   * \remarks for efficiency, no bounds checks; usually trying to
+   * access out of bounds causes a bus error
+   */
+  Point &operator[](unsigned i) { return vertices_[i]; }
+  /// erase all points
+  void clear() { vertices_.clear(); }
+  /// add a vertex to the back (end) of the list
+  void push_back(const Point &point_temp) { vertices_.push_back(point_temp); }
+  /// delete a vertex to the back (end) of the list
+  void pop_back() { vertices_.pop_back(); }
+  /// reset the whole list of vertices at once
+  void set_vertices(const std::vector<Point> &vertices_temp) {
+    vertices_ = vertices_temp;
+  }
+  /** \brief  eliminates vertices which are (\a epsilon) - colinear
+   *          with their respective neighbors
+   *
+   * \author  Karl J. Obermeyer
+   * \post  the Euclidean distance between each vertex and the line
+   * segment connecting its neighbors is at least \a epsilon
+   * \remarks time complexity O(n), where n is the number of
+   * vertices representing the Polyline.
+   */
+  void eliminate_redundant_vertices(double epsilon = 0.0);
+  // Reduce number of vertices in representation...
+  // void smooth(double epsilon);
+  /// reverse order of vertices
+  void reverse();
+  /// append the points from another polyline
+  void append(const Polyline &polyline);
+
+private:
+  std::vector<Point> vertices_;
+};
+
+// print Polyline
+std::ostream &operator<<(std::ostream &outs, const Polyline &polyline_temp);
+
+/** \brief simple polygon in the plane represented by list of vertices
+ *
+ * Simple here means non-self-intersecting.  More precisely, edges
+ * should not (i) intersect with an edge not adjacent to it, nor
+ * (ii) intersect at more than one Point with an adjacent edge.
+ * \remarks  vertices may be listed cw or ccw
+ */
+class Polygon {
+public:
+  friend class Point;
+  // Constructors
+  /// default to empty
+  Polygon() {}
+  /** \brief  construct from *.polygon file
+   *
+   * \author  Karl J. Obermeyer
+   * \remarks  for efficiency, simplicity check not called here
+   */
+  Polygon(const std::string &filename);
+  /** \brief  construct from vector of vertices
+   *
+   * \remarks  for efficiency, simplicity check not called here
+   */
+  Polygon(const std::vector<Point> &vertices_temp);
+  /** \brief  construct triangle from 3 Points
+   *
+   * \remarks  for efficiency, simplicity check not called here
+   */
+  Polygon(const Point &point0, const Point &point1, const Point &point2);
+  // Accessors
+  /** \brief  access with automatic wrap-around in forward direction
+   *
+   * \remarks  For efficiency, no bounds check; usually trying to
+   * access out of bounds causes a bus error
+   */
+  const Point &operator[](unsigned i) const {
+    return vertices_[i % vertices_.size()];
+  }
+  /** \brief  vertex count
+   *
+   * \remarks  O(1) time complexity
+   */
+  unsigned n() const { return vertices_.size(); }
+  /** \brief  reflex vertex count (nonconvex vertices)
+   *
+   * \author  Karl J. Obermeyer
+   * \remarks  Works regardless of polygon orientation (ccw vs cw),
+   * but assumes no redundant vertices.  Time complexity O(n), where
+   * n is the number of vertices representing the Polygon
+   */
+  unsigned r() const;
+  /** \brief  true iff Polygon is (\a epsilon) simple
+   *
+   * \author  Karl J. Obermeyer
+   *
+   * \remarks A Polygon is considered \a epsilon -simple iff (i) the
+   * Euclidean distance between nonadjacent edges is no greater than
+   * \a epsilon, (ii) adjacent edges intersect only at their single
+   * shared Point, (iii) and it has at least 3 vertices.  One
+   * consequence of these conditions is that there can be no
+   * redundant vertices.
+   */
+  bool is_simple(double epsilon = 0.0) const;
+  /** \brief true iff lexicographically smallest vertex is first in
+   *         the list of vertices representing the Polygon
+   *
+   * \author  Karl J. Obermeyer
    * \remarks  lex. comparison is very sensitive to perturbations if
    * two Points nearly define a line parallel to one of the axes
    */
-  bool  operator >= (const Point& point1, const Point& point2);
-  /** \brief  compare lexicographic order of points
-   *
-   * For Points p1 and p2, p1 < p2 iff either p1.x() < p2.x() or
-   * p1.x()==p2.x() and p1.y()<p2.y().  False if any member data have
-   * not been assigned (numbers).
-   * \remarks  lex. comparison is very sensitive to perturbations if
-   * two Points nearly define a line parallel to one of the axes
-   */
-  bool  operator <= (const Point& point1, const Point& point2);
-
-
-  /// vector addition of Points
-  Point operator +  (const Point& point1, const Point& point2);
-  /// vector subtraction of Points
-  Point operator -  (const Point& point1, const Point& point2);
-
-
-  //// dot (scalar) product treats the Points as vectors
-  Point operator *  (const Point& point1, const Point& point2);
-
-
-  /// simple scaling treats the Point as a vector
-  Point operator *  (double scalar, const Point& point2);
-  /// simple scaling treats the Point as a vector
-  Point operator *  (const Point&  point1, double scalar);
-
-
-  /** \brief  cross product (signed) magnitude treats the Points as vectors
+  bool is_in_standard_form() const;
+  /// perimeter length
+  double boundary_length() const;
+  /** oriented area of the Polygon
    *
    * \author  Karl J. Obermeyer
-   * \pre  Points' data are numbers
-   * \remarks This is equal to the (signed) area of the parallelogram created
-   * by the Points viewed as vectors.
+   * \pre Polygon is simple, but for efficiency simplicity is not asserted.
+   * area > 0 => vertices listed ccw,
+   * area < 0 => cw
+   * \remarks O(n) time complexity, where n is the number
+   * of vertices representing the Polygon
    */
-  double cross(const Point& point1, const Point& point2);
-
-
-  /** \brief  Euclidean distance between Points
-   *
-   * \pre  Points' data are numbers
-   */
-  double distance(const Point& point1, const Point& point2);
-
-
-  /** \brief  Euclidean distance between a Point and a Line_Segment
+  double area() const;
+  /** \brief  Polygon's centroid (center of mass)
    *
    * \author  Karl J. Obermeyer
-   * \pre  Point's data are numbers and the Line_Segment is nonempty
+   * \pre Polygon has greater than 0 vertices and is simple,
+   * but for efficiency simplicity is not asserted
    */
-  double distance(const Point& point_temp,
-		  const Line_Segment& line_segment_temp);
-  /** \brief  Euclidean distance between a Point and a Line_Segment
+  Point centroid() const;
+  /** \brief  Euclidean diameter
+   *
+   * \pre Polygon has greater than 0 vertices
+   * \return  maximum Euclidean distance between all pairs of
+   * vertices
+   * \remarks  time complexity O(n^2), where n is the number of
+   * vertices representing the Polygon
+   */
+  double diameter() const;
+  /** \brief box which fits snugly around the Polygon
    *
    * \author  Karl J. Obermeyer
-   * \pre  Point's data are numbers and the Line_Segment is nonempty
+   * \pre Polygon has greater than 0 vertices
    */
-  double distance(const Line_Segment& line_segment_temp,
-		  const Point& point_temp);
-
-
-  /** \brief  Euclidean distance between a Point and a Ray
+  Bounding_Box bbox() const;
+  // Returns a vector of n pts randomly situated in the polygon.
+  std::vector<Point> random_points(const unsigned &count,
+                                   double epsilon = 0.0) const;
+  /** \brief  write list of vertices to *.polygon file
    *
    * \author  Karl J. Obermeyer
-   * \pre  Point's and Ray's data are numbers
+   * Uses intuitive human and computer readable decimal format with
+   * display precision \a fios_precision_temp.
+   * \pre  \a fios_precision_temp >=1
    */
-  double distance(const Point& point_temp,
-		  const Ray& ray_temp);
-  /** \brief  Euclidean distance between a Point and a Ray
+  void write_to_file(const std::string &filename,
+                     int fios_precision_temp = FIOS_PRECISION);
+  // Mutators
+  /** \brief  access with automatic wrap-around in forward direction
+   *
+   * \remarks  for efficiency, no bounds check; usually trying to
+   * access out of bounds causes a bus error
+   */
+  Point &operator[](unsigned i) { return vertices_[i % vertices_.size()]; }
+  /// set vertices using STL vector of Points
+  void set_vertices(const std::vector<Point> &vertices_temp) {
+    vertices_ = vertices_temp;
+  }
+  /// push a Point onto the back of the vertex list
+  void push_back(const Point &vertex_temp) { vertices_.push_back(vertex_temp); }
+  /// erase all vertices
+  void clear() { vertices_.clear(); }
+  /** \brief enforces that the lexicographically smallest vertex is first
+   *         in the list of vertices representing the Polygon
    *
    * \author  Karl J. Obermeyer
-   * \pre  Point's and Ray's data are numbers
+   * \remarks  O(n) time complexity, where n is the number of
+   * vertices representing the Polygon.  Lex. comparison is very
+   * sensitive to perturbations if two Points nearly define a line
+   * parallel to one of the axes
    */
-  double distance(const Ray& ray_temp,
-		  const Point& point_temp);
-
-
-  /** \brief  Euclidean distance between a Point and a Polyline
+  void enforce_standard_form();
+  /** \brief  eliminates vertices which are (\a epsilon) - colinear
+   *          with their respective neighbors
    *
    * \author  Karl J. Obermeyer
-   * \pre  Point's data are numbers and the Polyline is nonempty
+   * \post  the Euclidean distance between each vertex and the line
+   * segment connecting its neighbors is at least \a epsilon, and the
+   * Polygon is in standard form
+   * \remarks  time complexity O(n), where n is the number of
+   * vertices representing the the Polygon
    */
-  double distance(const Point& point_temp,
-		  const Polyline& polyline_temp);
-  /** \brief  Euclidean distance between a Point and a Polyline
+  void eliminate_redundant_vertices(double epsilon = 0.0);
+  /** \brief  reverse (cyclic) order of vertices
+   *
+   * \remarks  vertex first in list is held first
+   */
+  void reverse();
+
+protected:
+  std::vector<Point> vertices_;
+};
+
+/** \brief  true iff vertex lists are identical, but false if either
+ *          Polygon has size 0
+ *
+ * \remarks returns false if either Polygon has size 0
+ * \remarks  O(n) time complexity
+ */
+bool operator==(Polygon polygon1, Polygon polygon2);
+bool operator!=(Polygon polygon1, Polygon polygon2);
+/** \brief true iff the Polygon's vertices match up w/in a (closed)
+ *         epsilon ball of each other, but false if either Polygon
+ *         has size 0
+ *
+ * Respects number, ordering, and orientation of vertices, i.e.,
+ * even if the (conceptual) polygons represented by two Polygons are
+ * identical, they are not considered \a epsilon - equivalent unless
+ * the number of vertices is the same, the orientations are the same
+ * (cw vs. ccw list), and the Points of the vertex lists match up
+ * within epsilon.  This function does attempt to match the polygons
+ * for all possible cyclic permutations, hence the quadratic time
+ * complexity.
+ * \author  Karl J. Obermeyer
+ * \remarks  O(n^2) time complexity, where n is the number of
+ * vertices representing the polygon
+ */
+bool equivalent(Polygon polygon1, Polygon polygon2, double epsilon = 0.0);
+
+/** \brief  Euclidean distance between Polygons' boundaries
+ *
+ * \author  Karl J. Obermeyer
+ * \pre  \a polygon1 and \a polygon2 each have greater than 0 vertices
+ */
+double boundary_distance(const Polygon &polygon1, const Polygon &polygon2);
+
+// print Polygon
+std::ostream &operator<<(std::ostream &outs, const Polygon &polygon_temp);
+
+/** \brief  environment represented by simple polygonal outer boundary
+ *          with simple polygonal holes
+ *
+ * \remarks  For methods to work correctly, the outer boundary vertices must
+ * be listed ccw and the hole vertices cw
+ */
+class Environment {
+public:
+  friend class Point;
+  // Constructors
+  /// default to empty
+  Environment() {}
+  /** \brief  construct Environment without holes
+   *
+   * \remarks  time complexity O(n), where n is the number of vertices
+   * representing the Environment
+   */
+  Environment(const Polygon &polygon_temp) {
+    outer_boundary_ = polygon_temp;
+    update_flattened_index_key();
+  }
+  /** \brief  construct Environment with holes from STL vector of Polygons
+   *
+   *  the first Polygon in the vector becomes the outer boundary,
+   *  the rest become the holes
+   * \remarks  time complexity O(n), where n is the number of vertices
+   * representing the Environment
+   */
+  Environment(const std::vector<Polygon> &polygons);
+  /** construct from *.environment file.
    *
    * \author  Karl J. Obermeyer
-   * \pre  Point's data are numbers and the Polyline is nonempty
+   * \remarks  time complexity O(n), where n is the number of vertices
+   * representing the Environment
    */
-  double distance(const Polyline& polyline_temp,
-		  const Point& point_temp);
-
-
-  /** \brief  Euclidean distance between a Point and a Polygon's boundary
+  Environment(const std::string &filename);
+  // Accessors
+  /** \brief  raw access to Polygons
    *
-   * \author  Karl J. Obermeyer
-   * \pre  Point's data are numbers and the Polygon is nonempty
+   * An argument of 0 accesses the outer boundary, 1 and above
+   * access the holes.
+   * \remarks  for efficiency, no bounds check; usually trying to
+   * access out of bounds causes a bus error
    */
-  double boundary_distance(const Point& point_temp,
-			   const Polygon& polygon_temp);
-  /** \brief  Euclidean distance between a Point and a Polygon's boundary
-   *
-   * \author  Karl J. Obermeyer
-   * \pre  Point's data are numbers and the Polygon is nonempty
-   */
-  double boundary_distance(const Polygon& polygon_temp,
-			   const Point& point_temp);
-
-
-  /** \brief  Euclidean distance between a Point and a Environment's boundary
-   *
-   * \author  Karl J. Obermeyer
-   * \pre  Point's data are numbers and the Environment is nonempty
-   */
-  double boundary_distance(const Point& point_temp,
-			   const Environment& environment_temp);
-  /** \brief  Euclidean distance between a Point and a Environment's boundary
-   *
-   * \author  Karl J. Obermeyer
-   * \pre  Point's data are numbers and the Environment is nonempty
-   */
-  double boundary_distance(const Environment& environment_temp,
-			   const Point& point_temp);
-
-
-  /// print a Point
-  std::ostream& operator << (std::ostream& outs, const Point& point_temp);
-
-
-  /** \brief line segment in the plane represented by its endpoints
-   *
-   * Closed and oriented line segment in the plane represented by its endpoints.
-   * \remarks  may be degenerate (colocated endpoints) or empty
-   */
-  class Line_Segment
-  {
-  public:
-    //Constructors
-    /// default to empty
-    Line_Segment();
-    /// copy constructor
-    Line_Segment(const Line_Segment& line_segment_temp);
-    /// construct degenerate segment from a single Point
-    Line_Segment(const Point& point_temp);
-    /// Line_Segment pointing from first_point_temp to second_point_temp
-    Line_Segment(const Point& first_point_temp,
-		 const Point& second_point_temp, double epsilon=0);
-    //Accessors
-    /** \brief  first endpoint
-     *
-     * \pre size() > 0
-     * \return  the first Point of the Line_Segment
-     * \remarks  If size() == 1, then both first() and second() are valid
-     * and will return the same Point
-     */
-    Point first()  const;
-    /** \brief  second endpoint
-     *
-     * \pre size() > 0
-     * \return  the second Point of the Line_Segment
-     * \remarks  If size() == 1, then both first() and second() are valid
-     * and will return the same Point
-     */
-    Point second() const;
-    /** \brief  number of distinct endpoints
-     *
-     * \remarks
-     * size 0 => empty line segment;
-     * size 1 => degenerate (single point) line segment;
-     * size 2 => full-fledged (bona fide) line segment
-     */
-    unsigned size() const { return size_; }
-    /** \brief midpoint
-     *
-     * \pre size() > 0
-     */
-    Point midpoint() const;
-    /** \brief Euclidean length
-     *
-     * \pre size() > 0
-     */
-    double length() const;
-    /** \brief  true iff vertices in lex. order
-     *
-     * \pre  size() > 0
-     * \return  true iff vertices are listed beginning with the vertex
-     * which is lexicographically smallest (lowest x, then lowest y)
-     * \remarks  lex. comparison is very sensitive to perturbations if
-     * two Points nearly define a line parallel to one of the axes
-     */
-    bool is_in_standard_form() const;
-    //Mutators
-    /// assignment operator
-    Line_Segment& operator = (const Line_Segment& line_segment_temp);
-    /** \brief set first endpoint
-     *
-     * \remarks  if \a point_temp is w/in a distance \a epsilon of an existing
-     * endpoint, the coordinates of \a point_temp are used and size is set to
-     * 1 as appropriate
-     */
-    void set_first(const Point& point_temp, double epsilon=0.0);
-    /** \brief set second endpoint
-     *
-     * \remarks  if \a point_temp is w/in a distance \a epsilon of an existing
-     * endpoint, the coordinates of \a point_temp are used and size is set to
-     * 1 as appropriate
-     */
-    void set_second(const Point& point_temp, double epsilon=0.0);
-    /** \brief  reverse order of endpoints
-     *
-     * \post order of endpoints is reversed.
-     */
-    void reverse();
-    /** \brief  enforce that lex. smallest endpoint first
-     *
-     * \post the lexicographically smallest endpoint (lowest x, then lowest y)
-     * is first
-     * \remarks  lex. comparison is very sensitive to perturbations if
-     * two Points nearly define a line parallel to one of the axes
-     */
-    void enforce_standard_form();
-    /// erase both endpoints and set line segment empty (size 0)
-    void clear();
-    /// destructor
-    virtual ~Line_Segment();
-  protected:
-    //Pointer to dynamic array of endpoints.
-    Point *endpoints_;
-    //See size() comments.
-    unsigned    size_;
-  };
-
-
-  /** \brief  true iff endpoint coordinates are exactly equal, but
-   *          false if either Line_Segment has size 0
-   *
-   * \remarks  respects ordering of vertices, i.e., even if the line segments
-   * overlap exactly, they are not considered == unless the orientations are
-   * the same
-   */
-  bool  operator == (const Line_Segment& line_segment1,
-		     const Line_Segment& line_segment2);
-  /// true iff endpoint coordinates are not ==
-  bool  operator != (const Line_Segment& line_segment1,
-		     const Line_Segment& line_segment2);
-
-
-  /** \brief  true iff line segments' endpoints match up w/in a (closed)
-   *          \a epsilon ball of each other, but false if either
-   *          Line_Segment has size 0
-   *
-   * \author  Karl J. Obermeyer
-   * \remarks  this function will return true even if it has to flip
-   * the orientation of one of the segments to get the vertices to
-   * match up
-   */
-  bool equivalent(Line_Segment line_segment1,
-		  Line_Segment line_segment2, double epsilon=0);
-
-
-  /** \brief  Euclidean distance between Line_Segments
-   *
-   * \author  Karl J. Obermeyer
-   * \pre  \a line_segment1.size() > 0 and \a line_segment2.size() > 0
-   */
-  double distance(const Line_Segment& line_segment1,
-		  const Line_Segment& line_segment2);
-
-
-  /** \brief  Euclidean distance between a Line_Segment and the
-   *          boundary of a Polygon
-   *
-   * \author  Karl J. Obermeyer
-   * \pre  \a line_segment.size() > 0 and \a polygon.n() > 0
-   */
-  double boundary_distance(const Line_Segment& line_segment,
-			   const Polygon& polygon);
-
-
-  /** \brief  Euclidean distance between a Line_Segment and the
-   *          boundary of a Polygon
-   *
-   * \author  Karl J. Obermeyer
-   * \pre  \a line_segment.size() > 0 and \a polygon.n() > 0
-   */
-  double boundary_distance(const Polygon& polygon,
-			   const Line_Segment& line_segment);
-
-
-  /** \brief  true iff the Euclidean distance between Line_Segments is
-   *          no greater than \a epsilon, false if either line segment
-   *          has size 0
-   *
-   * \author  Karl J. Obermeyer
-   */
-  bool intersect(const Line_Segment& line_segment1,
-		 const Line_Segment& line_segment2,
-		 double epsilon=0.0);
-
-
-  /** \brief  true iff line segments intersect properly w/in epsilon,
-   *          false if either line segment has size 0
-   *
-   * \author  Karl J. Obermeyer
-   * \return true iff Line_Segments intersect exactly at a single
-   * point in their relative interiors.  For robustness, here the
-   * relative interior of a Line_Segment is consider to be any Point
-   * in the Line_Segment which is a distance greater than \a epsilon
-   * from both endpoints.
-   */
-  bool intersect_proper(const Line_Segment& line_segment1,
-			const Line_Segment& line_segment2,
-			double epsilon=0.0);
-
-
-  /** \brief  intersection of Line_Segments
-   *
-   * \author  Karl J. Obermeyer
-   * \return a Line_Segment of size 0, 1, or 2
-   * \remarks  size 0 results if the distance (or at least the
-   * floating-point computed distance) between line_segment1 and
-   * line_segment2 is (strictly) greater than epsilon. size 1 results
-   * if the segments intersect poperly, form a T intersection, or --
-   * intersection.  size 2 results when two or more endpoints are a
-   * Euclidean distance no greater than \a epsilon from the opposite
-   * segment, and the overlap of the segments has a length greater
-   * than \a epsilon.
-   */
-  Line_Segment intersection(const Line_Segment& line_segment1,
-			    const Line_Segment& line_segment2,
-			    double epsilon=0.0);
-
-
-  /// print a Line_Segment
-  std::ostream& operator << (std::ostream& outs,
-			     const Line_Segment& line_segment_temp);
-
-
-  /** \brief  angle in radians represented by a value in
-   *          the interval [0,2*M_PI]
-   *
-   * \remarks  the intended interpretation is that angles 0 and 2*M_PI
-   * correspond to the positive x-axis of the coordinate system
-   */
-  class Angle
-  {
-  public:
-    //Constructors
-    /** \brief  default
-     *
-     * \remarks  data defaults to NAN so that checking whether the
-     * data are numbers can be used as a precondition in functions
-     */
-    Angle() : angle_radians_(NAN) { }
-    /// construct from real value, mod into interval [0, 2*M_PI)
-    Angle(double data_temp);
-    /** \brief construct using 4 quadrant inverse tangent into [0, 2*M_PI),
-     *         where 0 points along the x-axis
-     */
-    Angle(double rise_temp, double run_temp);
-    //Accessors
-    /// get radians
-    double get() const { return angle_radians_; }
-    //Mutators
-    /// set angle, mod into interval [0, 2*PI)
-    void set(double data_temp);
-    /** \brief  set angle data to 2*M_PI
-     *
-     * \remarks  sometimes it is necessary to set the angle value to
-     * 2*M_PI instead of 0, so that the lex. inequalities behave
-     * appropriately during a radial line sweep
-    */
-    void set_to_2pi() { angle_radians_=2*M_PI; }
-    /// set to new random angle in [0, 2*M_PI)
-    void randomize();
-  private:
-    double angle_radians_;
-  };
-
-
-  /// compare angle radians
-  bool operator  == (const Angle& angle1, const Angle& angle2);
-  /// compare angle radians
-  bool operator  != (const Angle& angle1, const Angle& angle2);
-
-
-  /// compare angle radians
-  bool operator  >  (const Angle& angle1, const Angle& angle2);
-  /// compare angle radians
-  bool operator  <  (const Angle& angle1, const Angle& angle2);
-  /// compare angle radians
-  bool operator  >= (const Angle& angle1, const Angle& angle2);
-  /// compare angle radians
-  bool operator  <= (const Angle& angle1, const Angle& angle2);
-
-
-  /// add angles' radians and mod into [0, 2*M_PI)
-  Angle operator +  (const Angle& angle1, const Angle& angle2);
-  /// subtract angles' radians and mod into [0, 2*M_PI)
-  Angle operator -  (const Angle& angle1, const Angle& angle2);
-
-
-  /** \brief  geodesic distance in radians between Angles
-   *
-   * \author  Karl J. Obermeyer
-   * \pre  \a angle1 and \a angle2 data are numbers
-   */
-  double geodesic_distance(const Angle& angle1, const Angle& angle2);
-
-
-  /** \brief  1.0 => geodesic path from angle1 to angle2
-   *          is couterclockwise, -1.0 => clockwise
-   *
-   * \author  Karl J. Obermeyer
-   * \pre  \a angle1 and \a angle2 data are numbers
-   */
-  double geodesic_direction(const Angle& angle1, const Angle& angle2);
-
-
-  /// print Angle
-  std::ostream& operator << (std::ostream& outs, const Angle& angle_temp);
-
-
-  /** \brief  Point in the plane packaged together with polar
-   *          coordinates w.r.t. specified origin
-   *
-   * The origin of the polar coordinate system is stored with the
-   * Polar_Point (in \a polar_origin_) and bearing is measured ccw from the
-   * positive x-axis.
-   * \remarks  used, e.g., for radial line sweeps
-   */
-  class Polar_Point : public Point
-  {
-  public:
-    //Constructors
-    /** \brief  default
-     *
-     * \remarks  Data defaults to NAN so that checking whether the
-     * data are numbers can be used as a precondition in functions.
-     */
-    Polar_Point() : Point(), range_(NAN), bearing_(NAN) { }
-    /** \brief  construct from (Cartesian) Points
-     *
-     * \pre  member data of \a polar_origin_temp and \a point_temp have
-     * been assigned (numbers)
-     * \param polar_origin_temp  the origin of the polar coordinate system
-     * \param point_temp  the point to be represented
-     * \remarks  if polar_origin_temp == point_temp, the default
-     * bearing is Angle(0.0)
-     */
-    Polar_Point(const Point& polar_origin_temp,
-		const Point& point_temp,
-		double epsilon=0.0);
-    //Accessors
-    /** \brief  origin of the polar coordinate system in which the point is
-     *          represented
-     */
-    Point polar_origin() const { return polar_origin_; }
-    /// Euclidean distance from the point represented to the origin of
-    /// the polar coordinate system
-    double       range() const { return range_; }
-    /// bearing from polar origin w.r.t. direction parallel to x-axis
-    Angle      bearing() const { return bearing_; }
-    //Mutators
-    /** \brief  set the origin of the polar coordinate system
-     *
-     * \remarks x and y held constant, bearing and range modified
-     * accordingly
-     */
-    void set_polar_origin(const Point& polar_origin_temp);
-    /** \brief  set x
-     *
-     * \remarks  polar_origin held constant, bearing and range modified
-     * accordingly
-     */
-    void set_x(double x_temp);
-    /** \brief  set y
-     *
-     * \remarks  polar_origin held constant, bearing and range modified
-     * accordingly
-     */
-    void set_y(double y_temp);
-    /** \brief set range
-     *
-     * \remarks  polar_origin held constant, x and y modified
-     * accordingly
-     */
-    void set_range(double range_temp);
-    /** \brief set bearing
-     *
-     * \remarks  polar_origin and range held constant, x and y modified
-     * accordingly
-     */
-    void set_bearing(const Angle& bearing_temp);
-    /** \brief  set bearing Angle data to 2*M_PI
-     *
-     * \remarks  Special function for use in computations involving a
-     * radial line sweep; sometimes it is necessary to set the angle
-     * value to 2*PI instead of 0, so that the lex. inequalities
-     * behave appropriately
-     */
-    void set_bearing_to_2pi() { bearing_.set_to_2pi(); }
-  protected:
-    //Origin of the polar coordinate system in world coordinates.
-    Point  polar_origin_;
-    //Polar coordinates where radius always positive, and angle
-    //measured ccw from the world coordinate system's x-axis.
-    double range_;
-    Angle  bearing_;
-  };
-
-
-  /** \brief  compare member data
-   *
-   * \remarks  returns false if any member data are NaN
-   */
-  bool operator == (const Polar_Point& polar_point1,
-		    const Polar_Point& polar_point2);
-  bool operator != (const Polar_Point& polar_point1,
-		    const Polar_Point& polar_point2);
-
-
-  /** \brief  compare according to polar lexicographic order
-   *          (smaller bearing, then smaller range)
-   *
-   *  false if any member data have not been assigned (numbers)
-   * \remarks  lex. comparison is very sensitive to perturbations if
-   * two Points nearly define a radial line
-   */
-  bool operator >  (const Polar_Point& polar_point1,
-			   const Polar_Point& polar_point2);
-  /** \brief  compare according to polar lexicographic order
-   *          (smaller bearing, then smaller range)
-   *
-   *  false if any member data have not been assigned (numbers)
-   * \remarks  lex. comparison is very sensitive to perturbations if
-   * two Points nearly define a radial line
-   */
-  bool operator <  (const Polar_Point& polar_point1,
-			   const Polar_Point& polar_point2);
-  /** \brief  compare according to polar lexicographic order
-   *          (smaller bearing, then smaller range)
-   *
-   *  false if any member data have not been assigned (numbers)
-   * \remarks  lex. comparison is very sensitive to perturbations if
-   * two Points nearly define a radial line
-   */
-  bool operator >= (const Polar_Point& polar_point1,
-			   const Polar_Point& polar_point2);
-  /** \brief  compare according to polar lexicographic order
-   *          (smaller bearing, then smaller range)
-   *
-   *  false if any member data have not been assigned (numbers)
-   * \remarks  lex. comparison is very sensitive to perturbations if
-   * two Points nearly define a radial line
-   */
-  bool operator <= (const Polar_Point& polar_point1,
-			   const Polar_Point& polar_point2);
-
-
-  /// print Polar_Point
-  std::ostream& operator << (std::ostream& outs,
-			     const Polar_Point& polar_point_temp);
-
-
-  /// ray in the plane represented by base Point and bearing Angle
-  class Ray
-  {
-  public:
-    //Constructors
-    /** \brief  default
-     *
-     * \remarks data defaults to NAN so that checking whether the data
-     * are numbers can be used as a precondition in functions
-     */
-    Ray() { }
-    /// construct ray emanating from \a base_point_temp in the direction
-    /// \a bearing_temp
-    Ray(Point base_point_temp, Angle bearing_temp) :
-    base_point_(base_point_temp) , bearing_(bearing_temp) {}
-    /// construct ray emanating from \a base_point_temp towards
-    /// \a bearing_point
-    Ray(Point base_point_temp, Point bearing_point);
-    //Accessors
-    /// get base point
-    Point base_point() const { return base_point_; }
-    /// get bearing
-    Angle bearing() const { return bearing_; }
-    //Mutators
-    /// set base point
-    void set_base_point(const Point& point_temp)
-    { base_point_ = point_temp; }
-    /// set bearing
-    void set_bearing(const Angle& angle_temp)
-    { bearing_ = angle_temp; }
-  private:
-    Point base_point_;
-    Angle bearing_;
-  };
-
-
-  /** \brief  compare member data
-   *
-   * \remarks  returns false if any member data are NaN
-   */
-  bool operator == (const Ray& ray1,
-		    const Ray& ray2);
-  /** \brief  compare member data
-   *
-   * \remarks  negation of ==
-   */
-  bool operator != (const Ray& ray1,
-		    const Ray& ray2);
-
-
-  /** \brief compute the intersection of a Line_Segment with a Ray
-   *
-   * \author  Karl J. Obermeyer
-   * \pre  member data of \a ray_temp has been assigned (numbers) and
-   * \a line_segment_temp has size greater than 0
-   * \remarks  as a convention, if the intersection has positive
-   * length, the Line_Segment returned has the first point closest to
-   * the Ray's base point
-   */
-  Line_Segment intersection(const Ray ray_temp,
-			    const Line_Segment& line_segment_temp,
-			    double epsilon=0.0);
-  /** \brief compute the intersection of a Line_Segment with a Ray
-   *
-   * \author  Karl J. Obermeyer
-   * \pre  member data of \a ray_temp has been assigned (numbers) and
-   * \a line_segment_temp has size greater than 0
-   * \remarks  as a convention, if the intersection has positive
-   * length, the Line_Segment returned has the first point closest to
-   * the Ray's base point
-   */
-  Line_Segment intersection(const Line_Segment& line_segment_temp,
-			    const Ray& ray_temp,
-			    double epsilon=0.0);
-
-
-  ///oriented polyline in the plane represented by list of vertices
-  class Polyline
-  {
-  public:
-    friend class Point;
-    //Constructors
-    /// default to empty
-    Polyline() { }
-    /// construct from vector of vertices
-    Polyline(const std::vector<Point>& vertices_temp)
-    { vertices_ = vertices_temp; }
-    //Accessors
-    /** \brief  raw access
-     *
-     * \remarks for efficiency, no bounds checks; usually trying to
-     * access out of bounds causes a bus error
-     */
-    Point operator [] (unsigned i) const
-    { return vertices_[i]; }
-    /// vertex count
-    unsigned size() const
-    { return vertices_.size(); }
-    /// Euclidean length of the Polyline
-    double length() const;
-    /** \brief  Euclidean diameter
-     *
-     * \pre  Polyline has greater than 0 vertices
-     * \return  the maximum Euclidean distance between all pairs of
-     * vertices
-     * \remarks  time complexity O(n^2), where n is the number of
-     * vertices representing the Polyline
-     */
-    double diameter() const;
-    //a box which fits snugly around the Polyline
-    Bounding_Box bbox() const;
-    //Mutators
-    /** \brief  raw access
-     *
-     * \remarks for efficiency, no bounds checks; usually trying to
-     * access out of bounds causes a bus error
-     */
-    Point& operator [] (unsigned i)
-    { return vertices_[i]; }
-    /// erase all points
-    void clear()
-    { vertices_.clear(); }
-    /// add a vertex to the back (end) of the list
-    void push_back(const Point& point_temp)
-    { vertices_.push_back(point_temp); }
-    /// delete a vertex to the back (end) of the list
-    void pop_back()
-    { vertices_.pop_back(); }
-    /// reset the whole list of vertices at once
-    void set_vertices(const std::vector<Point>& vertices_temp)
-    { vertices_ = vertices_temp; }
-    /** \brief  eliminates vertices which are (\a epsilon) - colinear
-     *          with their respective neighbors
-     *
-     * \author  Karl J. Obermeyer
-     * \post  the Euclidean distance between each vertex and the line
-     * segment connecting its neighbors is at least \a epsilon
-     * \remarks time complexity O(n), where n is the number of
-     * vertices representing the Polyline.
-     */
-    void eliminate_redundant_vertices(double epsilon=0.0);
-    //Reduce number of vertices in representation...
-    //void smooth(double epsilon);
-    /// reverse order of vertices
-    void reverse();
-    /// append the points from another polyline
-    void append( const Polyline& polyline );
-  private:
-    std::vector<Point> vertices_;
-  };
-
-
-  //print Polyline
-  std::ostream& operator << (std::ostream& outs,
-			     const Polyline& polyline_temp);
-
-
-  /** \brief simple polygon in the plane represented by list of vertices
-   *
-   * Simple here means non-self-intersecting.  More precisely, edges
-   * should not (i) intersect with an edge not adjacent to it, nor
-   * (ii) intersect at more than one Point with an adjacent edge.
-   * \remarks  vertices may be listed cw or ccw
-   */
-  class Polygon
-  {
-  public:
-    friend class Point;
-    //Constructors
-    ///default to empty
-    Polygon() { }
-    /** \brief  construct from *.polygon file
-     *
-     * \author  Karl J. Obermeyer
-     * \remarks  for efficiency, simplicity check not called here
-     */
-    Polygon(const std::string& filename);
-    /** \brief  construct from vector of vertices
-     *
-     * \remarks  for efficiency, simplicity check not called here
-     */
-    Polygon(const std::vector<Point>& vertices_temp);
-    /** \brief  construct triangle from 3 Points
-     *
-     * \remarks  for efficiency, simplicity check not called here
-     */
-    Polygon(const Point& point0, const Point& point1, const Point& point2);
-    //Accessors
-    /** \brief  access with automatic wrap-around in forward direction
-     *
-     * \remarks  For efficiency, no bounds check; usually trying to
-     * access out of bounds causes a bus error
-     */
-    const Point& operator [] (unsigned i) const
-    { return vertices_[i % vertices_.size()]; }
-    /** \brief  vertex count
-     *
-     * \remarks  O(1) time complexity
-     */
-    unsigned n() const { return vertices_.size(); }
-    /** \brief  reflex vertex count (nonconvex vertices)
-     *
-     * \author  Karl J. Obermeyer
-     * \remarks  Works regardless of polygon orientation (ccw vs cw),
-     * but assumes no redundant vertices.  Time complexity O(n), where
-     * n is the number of vertices representing the Polygon
-     */
-    unsigned r() const;
-    /** \brief  true iff Polygon is (\a epsilon) simple
-     *
-     * \author  Karl J. Obermeyer
-     *
-     * \remarks A Polygon is considered \a epsilon -simple iff (i) the
-     * Euclidean distance between nonadjacent edges is no greater than
-     * \a epsilon, (ii) adjacent edges intersect only at their single
-     * shared Point, (iii) and it has at least 3 vertices.  One
-     * consequence of these conditions is that there can be no
-     * redundant vertices.
-     */
-    bool is_simple(double epsilon=0.0) const;
-    /** \brief true iff lexicographically smallest vertex is first in
-     *         the list of vertices representing the Polygon
-     *
-     * \author  Karl J. Obermeyer
-     * \remarks  lex. comparison is very sensitive to perturbations if
-     * two Points nearly define a line parallel to one of the axes
-     */
-    bool is_in_standard_form() const;
-    /// perimeter length
-    double boundary_length() const;
-    /** oriented area of the Polygon
-     *
-     * \author  Karl J. Obermeyer
-     * \pre Polygon is simple, but for efficiency simplicity is not asserted.
-     * area > 0 => vertices listed ccw,
-     * area < 0 => cw
-     * \remarks O(n) time complexity, where n is the number
-     * of vertices representing the Polygon
-     */
-    double area() const;
-    /** \brief  Polygon's centroid (center of mass)
-     *
-     * \author  Karl J. Obermeyer
-     * \pre Polygon has greater than 0 vertices and is simple,
-     * but for efficiency simplicity is not asserted
-     */
-    Point  centroid() const;
-    /** \brief  Euclidean diameter
-     *
-     * \pre Polygon has greater than 0 vertices
-     * \return  maximum Euclidean distance between all pairs of
-     * vertices
-     * \remarks  time complexity O(n^2), where n is the number of
-     * vertices representing the Polygon
-     */
-    double diameter() const;
-    /** \brief box which fits snugly around the Polygon
-     *
-     * \author  Karl J. Obermeyer
-     * \pre Polygon has greater than 0 vertices
-     */
-    Bounding_Box bbox() const;
-    // Returns a vector of n pts randomly situated in the polygon.
-    std::vector<Point> random_points(const unsigned& count,
-				     double epsilon=0.0) const;
-    /** \brief  write list of vertices to *.polygon file
-     *
-     * \author  Karl J. Obermeyer
-     * Uses intuitive human and computer readable decimal format with
-     * display precision \a fios_precision_temp.
-     * \pre  \a fios_precision_temp >=1
-     */
-    void write_to_file(const std::string& filename,
-		       int fios_precision_temp=FIOS_PRECISION);
-    //Mutators
-    /** \brief  access with automatic wrap-around in forward direction
-     *
-     * \remarks  for efficiency, no bounds check; usually trying to
-     * access out of bounds causes a bus error
-     */
-    Point& operator [] (unsigned i) { return vertices_[i % vertices_.size()]; }
-    /// set vertices using STL vector of Points
-    void set_vertices(const std::vector<Point>& vertices_temp)
-    { vertices_ = vertices_temp; }
-    /// push a Point onto the back of the vertex list
-    void push_back(const Point& vertex_temp )
-    { vertices_.push_back( vertex_temp ); }
-    /// erase all vertices
-    void clear()
-    { vertices_.clear(); }
-    /** \brief enforces that the lexicographically smallest vertex is first
-     *         in the list of vertices representing the Polygon
-     *
-     * \author  Karl J. Obermeyer
-     * \remarks  O(n) time complexity, where n is the number of
-     * vertices representing the Polygon.  Lex. comparison is very
-     * sensitive to perturbations if two Points nearly define a line
-     * parallel to one of the axes
-     */
-    void enforce_standard_form();
-    /** \brief  eliminates vertices which are (\a epsilon) - colinear
-     *          with their respective neighbors
-     *
-     * \author  Karl J. Obermeyer
-     * \post  the Euclidean distance between each vertex and the line
-     * segment connecting its neighbors is at least \a epsilon, and the
-     * Polygon is in standard form
-     * \remarks  time complexity O(n), where n is the number of
-     * vertices representing the the Polygon
-     */
-    void eliminate_redundant_vertices(double epsilon=0.0);
-    /** \brief  reverse (cyclic) order of vertices
-     *
-     * \remarks  vertex first in list is held first
-     */
-    void reverse();
-  protected:
-    std::vector<Point> vertices_;
-  };
-
-
-  /** \brief  true iff vertex lists are identical, but false if either
-   *          Polygon has size 0
-   *
-   * \remarks returns false if either Polygon has size 0
-   * \remarks  O(n) time complexity
-   */
-  bool operator == (Polygon polygon1, Polygon polygon2);
-  bool operator != (Polygon polygon1, Polygon polygon2);
-  /** \brief true iff the Polygon's vertices match up w/in a (closed)
-   *         epsilon ball of each other, but false if either Polygon
-   *         has size 0
-   *
-   * Respects number, ordering, and orientation of vertices, i.e.,
-   * even if the (conceptual) polygons represented by two Polygons are
-   * identical, they are not considered \a epsilon - equivalent unless
-   * the number of vertices is the same, the orientations are the same
-   * (cw vs. ccw list), and the Points of the vertex lists match up
-   * within epsilon.  This function does attempt to match the polygons
-   * for all possible cyclic permutations, hence the quadratic time
-   * complexity.
-   * \author  Karl J. Obermeyer
-   * \remarks  O(n^2) time complexity, where n is the number of
-   * vertices representing the polygon
-   */
-  bool equivalent(Polygon polygon1, Polygon polygon2,
-		  double epsilon=0.0);
-
-
-  /** \brief  Euclidean distance between Polygons' boundaries
-   *
-   * \author  Karl J. Obermeyer
-   * \pre  \a polygon1 and \a polygon2 each have greater than 0 vertices
-   */
-  double boundary_distance( const Polygon& polygon1,
-			    const Polygon& polygon2 );
-
-
-  //print Polygon
-  std::ostream& operator << (std::ostream& outs,
-			     const Polygon& polygon_temp);
-
-
-  /** \brief  environment represented by simple polygonal outer boundary
-   *          with simple polygonal holes
-   *
-   * \remarks  For methods to work correctly, the outer boundary vertices must
-   * be listed ccw and the hole vertices cw
-   */
-  class Environment
-  {
-  public:
-    friend class Point;
-    //Constructors
-    /// default to empty
-    Environment() { }
-    /** \brief  construct Environment without holes
-     *
-     * \remarks  time complexity O(n), where n is the number of vertices
-     * representing the Environment
-     */
-    Environment(const Polygon& polygon_temp)
-    { outer_boundary_=polygon_temp; update_flattened_index_key(); }
-    /** \brief  construct Environment with holes from STL vector of Polygons
-     *
-     *  the first Polygon in the vector becomes the outer boundary,
-     *  the rest become the holes
-     * \remarks  time complexity O(n), where n is the number of vertices
-     * representing the Environment
-     */
-    Environment(const std::vector<Polygon>& polygons);
-    /** construct from *.environment file.
-     *
-     * \author  Karl J. Obermeyer
-     * \remarks  time complexity O(n), where n is the number of vertices
-     * representing the Environment
-     */
-    Environment(const std::string& filename);
-    //Accessors
-    /** \brief  raw access to Polygons
-     *
-     * An argument of 0 accesses the outer boundary, 1 and above
-     * access the holes.
-     * \remarks  for efficiency, no bounds check; usually trying to
-     * access out of bounds causes a bus error
-     */
-    const Polygon& operator [] (unsigned i) const
-    { if(i==0){return outer_boundary_;} else{return holes_[i-1];} }
-    /** \brief  raw access to vertices via flattened index
-     *
-     * By flattened index is intended the label given to a vertex if
-     * you were to label all the vertices from 0 to n-1 (where n is
-     * the number of vertices representing the Environment) starting
-     * with the first vertex of the outer boundary and progressing in
-     * order through all the remaining vertices of the outer boundary
-     * and holes.
-     *
-     * \remarks  Time complexity O(1).  For efficiency, no bounds
-     * check; usually trying to access out of bounds causes a bus
-     * error.
-     */
-    const Point& operator () (unsigned k) const;
-    /// hole count
-    unsigned h() const { return holes_.size(); }
-    /** \brief  vertex count
-     *
-     * \remarks  time complexity O(h)
-     */
-    unsigned n() const;
-    /** \brief  total reflex vertex count (nonconvex vertices)
-     *
-     * \author  Karl J. Obermeyer
-     * \remarks  time complexity O(n), where n is the number of
-     * vertices representing the Environment
-     */
-    unsigned r() const;
-    /** \brief  true iff lexicographically smallest vertex is first in
-     *          each list of vertices representing a Polygon of the
-     *          Environment
-     *
-     * \author  Karl J. Obermeyer
-     * \remarks  lex. comparison is very sensitive to perturbations if
-     * two Points nearly define a line parallel to one of the axes
-     */
-    bool is_in_standard_form() const;
-    /** \brief  true iff \a epsilon -valid
-     *
-     * \a epsilon -valid means (i) the outer boundary and holes are
-     * pairwise \a epsilon -disjoint (no two features should come
-     * within \a epsilon of each other) simple polygons, (ii) outer
-     * boundary is oriented ccw, and (iii) holes are oriented cw.
-     *
-     * \author  Karl J. Obermeyer
-     *
-     * \pre  Environment has greater than 2 vertices
-     * (otherwise it can't even have nonzero area)
-     * \remarks time complexity O(h^2*n^2), where h is the number of
-     * holes and n is the number of vertices representing the
-     * Environment
-     */
-    bool is_valid(double epsilon=0.0) const;
-    /** \brief  sum of perimeter lengths of outer boundary and holes
-     *
-     * \author  Karl J. Obermeyer
-     * \remarks O(n) time complexity, where n is the number of
-     * vertices representing the Environment
-     */
-    double boundary_length() const;
-    /** \brief (obstacle/hole free) area of the Environment
-     *
-     * \author  Karl J. Obermeyer
-     * \remarks  O(n) time complexity, where n is the number of
-     * vertices representing the Environment
-     */
-    double area() const;
-    /** \brief  Euclidean diameter
-     *
-     * \author  Karl J. Obermeyer
-     * \pre Environment has greater than 0 vertices
-     * \return  maximum Euclidean distance between all pairs of
-     * vertices
-     * \remarks  time complexity O(n^2), where n is the number of
-     * vertices representing the Environment
-     */
-    double diameter() const { return outer_boundary_.diameter(); }
-    /** \brief box which fits snugly around the Environment
-     *
-     * \author  Karl J. Obermeyer
-     * \pre Environment has greater than 0 vertices
-     */
-    Bounding_Box bbox() const { return outer_boundary_.bbox(); }
-    /** \brief get STL vector of \a count Points randomly situated
-     *         within \a epsilon of the Environment
-     *
-     * \author  Karl J. Obermeyer
-     * \pre  the Environment has positive area
-     */
-    std::vector<Point> random_points(const unsigned& count,
-				     double epsilon=0.0) const;
-    /** \brief  compute a shortest path between 2 Points
-     *
-     * Uses the classical visibility graph method as described, e.g.,
-     * in ``Robot Motion Planning" (Ch. 4 Sec. 1) by J.C. Latombe.
-     * Specifically, an A* search is performed on the visibility graph
-     * using the Euclidean distance as the heuristic function.
-     *
-     * \author  Karl J. Obermeyer
-     *
-     * \pre \a start and \a finish must be in the environment.
-     * Environment must be \a epsilon -valid.  Test with
-     * Environment::is_valid(epsilon).
-     *
-     * \remarks  If multiple shortest path queries are made for the
-     * same Envrionment, it is better to precompute the
-     * Visibility_Graph. For a precomputed Visibility_Graph, the time
-     * complexity of a shortest_path() query is O(n^2), where n is the
-     * number of vertices representing the Environment.
-     *
-     * \todo  return not just one, but all shortest paths (w/in
-     * epsilon), e.g., returning a std::vector<Polyline>)
-     */
-    Polyline shortest_path(const Point& start,
-			   const Point& finish,
-			   const Visibility_Graph& visibility_graph,
-			   double epsilon=0.0);
-    /** \brief  compute shortest path between 2 Points
-     *
-     * \author  Karl J. Obermeyer
-     *
-     * \pre \a start and \a finish must be in the environment.
-     * Environment must be \a epsilon -valid.  Test with
-     * Environment::is_valid(epsilon).
-     *
-     * \remarks  For single shortest path query, visibility graph is
-     * not precomputed.  Time complexity O(n^3), where n is the number
-     * of vertices representing the Environment.
-     */
-    Polyline shortest_path(const Point& start,
-			   const Point& finish,
-			   double epsilon=0.0);
-    /** \brief  compute the faces (partition cells) of an arrangement
-     *          of Line_Segments inside the Environment
-     *
-     * \author  Karl J. Obermeyer
-     * \todo  finish this
-     */
-    std::vector<Polygon> compute_partition_cells( std::vector<Line_Segment>
-						  partition_inducing_segments,
-						  double epsilon=0.0 )
-    {
-      std::vector<Polygon> cells;
-      return cells;
+  const Polygon &operator[](unsigned i) const {
+    if (i == 0) {
+      return outer_boundary_;
+    } else {
+      return holes_[i - 1];
     }
-    /** \brief  write lists of vertices to *.environment file
-     *
-     * uses intuitive human and computer readable decimal format with
-     * display precision \a fios_precision_temp
-     * \author  Karl J. Obermeyer
-     * \pre  \a fios_precision_temp >=1
-     */
-    void write_to_file(const std::string& filename,
-		       int fios_precision_temp=FIOS_PRECISION);
-    //Mutators
-    /** \brief  raw access to Polygons
-     *
-     * An argument of 0 accesses the outer boundary, 1 and above
-     * access the holes.
-     * \author  Karl J. Obermeyer
-     * \remarks  for efficiency, no bounds check; usually trying to
-     * access out of bounds causes a bus error
-     */
-    Polygon& operator [] (unsigned i)
-    { if(i==0){return outer_boundary_;} else{return holes_[i-1];} }
-    //Mutators
-    /** \brief  raw access to vertices via flattened index
-     *
-     * By flattened index is intended the label given to a vertex if
-     * you were to label all the vertices from 0 to n-1 (where n is
-     * the number of vertices representing the Environment) starting
-     * with the first vertex of the outer boundary and progressing in
-     * order through all the remaining vertices of the outer boundary
-     * and holes.
-     * \author  Karl J. Obermeyer
-     * \remarks  for efficiency, no bounds check; usually trying to
-     * access out of bounds causes a bus error.
-     */
-    Point& operator () (unsigned k);
-    /// set outer boundary
-    void set_outer_boundary(const Polygon& polygon_temp)
-    { outer_boundary_ = polygon_temp; update_flattened_index_key(); }
-    /// add hole
-    void add_hole(const Polygon& polygon_temp)
-    { holes_.push_back(polygon_temp); update_flattened_index_key(); }
-    /** \brief enforces outer boundary vertices are listed ccw and
-     *         holes listed cw, and that these lists begin with respective
-     *         lexicographically smallest vertex
-     *
-     * \author  Karl J. Obermeyer
-     * \remarks  O(n) time complexity, where n is the number of
-     * vertices representing the Environment.  Lex. comparison is very
-     * sensitive to perturbations if two Points nearly define a line
-     * parallel to one of the axes.
-     */
-    void enforce_standard_form();
-    /** \brief eliminates vertices which are (\a epsilon) - colinear
-     *         with their respective neighbors
-     *
-     * \author  Karl J. Obermeyer
-     * \post  the Euclidean distance between each vertex and the line
-     * segment connecting its neighbors is at least \a epsilon
-     * \remarks time complexity O(n), where n is the number of
-     * vertices representing the the Environment
-     */
-    void eliminate_redundant_vertices(double epsilon=0.0);
-    /** \brief  reverse (cyclic) order of vertices belonging to holes
-     *          only
-     *
-     * \remarks  vertex first in each hole's list is held first
-     */
-    void reverse_holes();
-  private:
-    Polygon outer_boundary_;
-    //obstacles
-    std::vector<Polygon> holes_;
-    //allows constant time access to vertices via operator () with
-    //flattened index as argument
-    std::vector< std::pair<unsigned,unsigned> > flattened_index_key_;
-    //Must call if size of outer_boundary and/or holes_ changes.  Time
-    //complexity O(n), where n is the number of vertices representing
-    //the Environment.
-    void update_flattened_index_key();
-    //converts flattened index to index pair (hole #, vertex #) in
-    //time O(n), where n is the number of vertices representing the
-    //Environment
-    std::pair<unsigned,unsigned> one_to_two(unsigned k) const;
-    //node used for search tree of A* search in shortest_path() method
-    class Shortest_Path_Node
-    {
-    public:
-      //flattened index of corresponding Environment vertex
-      //convention vertex_index = n() => corresponds to start Point
-      //vertex_index = n() + 1 => corresponds to finish Point
-      unsigned vertex_index;
-      //pointer to self in search tree.
-      std::list<Shortest_Path_Node>::iterator search_tree_location;
-      //pointer to parent in search tree.
-      std::list<Shortest_Path_Node>::iterator parent_search_tree_location;
-      //Geodesic distance from start Point.
-      double cost_to_come;
-      //Euclidean distance to finish Point.
-      double estimated_cost_to_go;
-      //std::vector<Shortest_Path_Node> expand();
-      bool operator < (const Shortest_Path_Node& spn2) const
-      {
-	double f1 = this->cost_to_come + this->estimated_cost_to_go;
-	double f2 = spn2.cost_to_come + spn2.estimated_cost_to_go;
-	if( f1 < f2 )
-	  return true;
-	else if( f2 < f1 )
-	  return false;
-	else if( this->vertex_index < spn2.vertex_index )
-	  return true;
-	else if( this->vertex_index > spn2.vertex_index )
-	  return false;
-	else if( &(*(this->parent_search_tree_location))
-		 < &(*(spn2.parent_search_tree_location)) )
-	  return true;
-	else
-	  return false;
-      }
-      // print member data for debugging
-      void print() const
-      {
-	std::cout << "         vertex_index = " << vertex_index << std::endl
-		  << "parent's vertex_index = "
-		  << parent_search_tree_location->vertex_index
-		  << std::endl
-		  << "         cost_to_come = " << cost_to_come << std::endl
-		  << " estimated_cost_to_go = "
-		  << estimated_cost_to_go << std::endl;
-      }
-    };
-  };
-
-
-  /// printing Environment
-  std::ostream& operator << (std::ostream& outs,
-			     const Environment& environment_temp);
-
-
-  /** \brief  set of Guards represented by a list of Points
+  }
+  /** \brief  raw access to vertices via flattened index
+   *
+   * By flattened index is intended the label given to a vertex if
+   * you were to label all the vertices from 0 to n-1 (where n is
+   * the number of vertices representing the Environment) starting
+   * with the first vertex of the outer boundary and progressing in
+   * order through all the remaining vertices of the outer boundary
+   * and holes.
+   *
+   * \remarks  Time complexity O(1).  For efficiency, no bounds
+   * check; usually trying to access out of bounds causes a bus
+   * error.
    */
-  class Guards
-  {
-  public:
-    friend class Visibility_Graph;
-    //Constructors
-    /// default to empty
-    Guards() { }
-    /** \brief  construct from *.guards file
-     *
-     * \author  Karl J. Obermeyer
-     */
-    Guards(const std::string& filename);
-    /// construct from STL vector of Points
-    Guards(const std::vector<Point>& positions)
-    { positions_ = positions; }
-    //Accessors
-    /** \brief  raw access to guard position Points
-     *
-     * \author  Karl J. Obermeyer
-     * \remarks  for efficiency, no bounds check; usually trying to
-     * access out of bounds causes a bus error
-     */
-    const Point& operator [] (unsigned i) const { return positions_[i]; }
-    /// guard count
-    unsigned N() const { return positions_.size(); }
-    /// true iff positions are lexicographically ordered
-    bool are_lex_ordered() const;
-    /// true iff no two guards are w/in epsilon of each other
-    bool noncolocated(double epsilon=0.0) const;
-    /// true iff all guards are located in \a polygon_temp
-    bool in(const Polygon& polygon_temp, double epsilon=0.0) const;
-    /// true iff all guards are located in \a environment_temp
-    bool in(const Environment& environment_temp, double epsilon=0.0) const;
-    /** \brief  Euclidean diameter
-     *
-     * \author  Karl J. Obermeyer
-     * \pre  greater than 0 guards
-     * \return  maximum Euclidean distance between all pairs of
-     * vertices
-     * \remarks  time complexity O(N^2), where N is the number of
-     * guards
-     */
-    double diameter() const;
-    /** \brief box which fits snugly around the Guards
-     *
-     * \author  Karl J. Obermeyer
-     * \pre  greater than 0 guards
-     */
-    Bounding_Box bbox() const;
-    /** \brief  write list of positions to *.guards file
-     *
-     * Uses intuitive human and computer readable decimal format with
-     * display precision \a fios_precision_temp.
-     * \author  Karl J. Obermeyer
-     * \pre  \a fios_precision_temp >=1
-     */
-    void write_to_file(const std::string& filename,
-		       int fios_precision_temp=FIOS_PRECISION);
-    //Mutators
-    /** \brief  raw access to guard position Points
-     *
-     * \author  Karl J. Obermeyer
-     * \remarks  for efficiency, no bounds check; usually trying to
-     * access out of bounds causes a bus error
-     */
-    Point& operator [] (unsigned i) { return positions_[i]; }
-    /// add a guard
-    void push_back(const Point& point_temp)
-    { positions_.push_back(point_temp); }
-    /// set positions with STL vector of Points
-    void set_positions(const std::vector<Point>& positions_temp)
-    { positions_ = positions_temp; }
-    /** \brief sort positions in lexicographic order
-     *
-     * from (lowest x, then lowest y) to (highest x, then highest y)
-     * \author  Karl J. Obermeyer
-     * \remarks time complexity O(N logN), where N is the guard count.
-     * Lex. comparison is very sensitive to perturbations if two
-     * Points nearly define a line parallel to one of the axes.
-     */
-    void enforce_lex_order();
-    /// reverse order of positions
-    void reverse();
-    /** \brief relocate each guard to closest vertex if within
-     *         \a epsilon of some vertex (of \a environment_temp)
-     *
-     * \author  Karl J. Obermeyer
-     * \pre  the guards' position data are numbers and \a environment_temp
-     * is nonempty
-     * \post if a guard was a Euclidean distance no greater
-     * than \a epsilon from any vertex of \a environment_temp, then it
-     * will be repositioned to coincide with the closest such vertex
-     * \remarks O(N*n) time complexity, where N is the guard count
-     * and n is the number of vertices in \a environment_temp.
-     */
-    void snap_to_vertices_of(const Environment& environment_temp,
-			     double epsilon=0.0);
-
-    /** \brief relocate each guard to closest vertex if within
-     *         \a epsilon of some vertex (of \a environment_temp)
-     *
-     * \author  Karl J. Obermeyer
-     * \pre  the guards' position data are numbers and \a polygon_temp
-     * is nonempty
-     * \post if a guard was a Euclidean distance no greater
-     * than \a epsilon from any vertex of \a polygon_temp, then it
-     * will be repositioned to coincide with the closest such vertex
-     * \remarks O(N*n) time complexity, where N is the guard count
-     * and n is the number of vertices in \a polygon_temp
-     */
-    void snap_to_vertices_of(const Polygon& polygon_temp,
-			     double epsilon=0.0);
-    /** \brief  relocate each guard to closest Point on boundary if
-     *	        within \a epsilon of the boundary (of \a environment_temp)
-     *
-     * \author  Karl J. Obermeyer
-     * \pre  the guards' position data are numbers and \a environment_temp
-     * is nonempty
-     * \post If the calling Point was a Euclidean distance no greater
-     * than \a epsilon from the boundary of \a environment_temp, then it
-     * will be repositioned to it's projection onto that boundary
-     * \remarks O(N*n) time complexity, where N is the guard count and
-     * n is the number of vertices in \a environment_temp
-     */
-    void snap_to_boundary_of(const Environment& environment_temp,
-			     double epsilon=0.0);
-    /** \brief  relocate each guard to closest Point on boundary if
-     *	        within \a epsilon of the boundary (of \a polygon_temp)
-     *
-     * \author  Karl J. Obermeyer
-     * \pre  the guards' position data are numbers and \a polygon_temp
-     * is nonempty
-     * \post If the calling Point was a Euclidean distance no greater
-     * than \a epsilon from the boundary of \a polygon_temp, then it
-     * will be repositioned to it's projection onto that boundary
-     * \remarks O(N*n) time complexity, where N is the guard count and
-     * n is the number of vertices in \a polygon_temp
-     */
-    void snap_to_boundary_of(const Polygon& polygon_temp,
-			     double epsilon=0.0);
-  private:
-    std::vector<Point> positions_;
-  };
-
-
-  /// print Guards
-  std::ostream& operator << (std::ostream& outs,
-			     const Guards& guards);
-
-
-  /** \brief visibility polygon of a Point in an Environment or Polygon
+  const Point &operator()(unsigned k) const;
+  /// hole count
+  unsigned h() const { return holes_.size(); }
+  /** \brief  vertex count
    *
-   * A Visibility_Polygon represents the closure of the set of all
-   * points in an environment which are {\it clearly visible} from a
-   * point (the observer).  Two Points p1 and p2 are (mutually) {\it
-   * clearly visible} in an environment iff the relative interior of
-   * the line segment connecting p1 and p2 does not intersect the
-   * boundary of the environment.
-   *
-   * \remarks  average case time complexity O(n log(n)), where n is the
-   * number of vertices in the Evironment (resp. Polygon).  Note the
-   * Standard Library's sort() function performs O(n log(n))
-   * comparisons (both average and worst-case) and the sort() member
-   * function of an STL list performs "approximately O(n log(n))
-   * comparisons".  For robustness, any Point (observer) should be \a
-   * epsilon -snapped to the environment boundary and vertices before
-   * computing its Visibility_Polygon (use the Point methods
-   * snap_to_vertices_of(...) and snap_to_boundary_of(...) ).
+   * \remarks  time complexity O(h)
    */
-  class Visibility_Polygon : public Polygon
-  {
-  public:
-    //Constructors
-    /// default to empty
-    Visibility_Polygon() { }
-    //:TRICKY:
-    /** \brief visibility set of a Point in an Environment
-     *
-     * \author  Karl J. Obermeyer
-     *
-     * \pre \a observer is in \a environment_temp (w/in \a epsilon )
-     * and has been epsilon-snapped to the Environment using the
-     * method Point::snap_to_boundary_of() followed by (order is
-     * important) Point::snap_to_vertices_of(). \a environment_temp
-     * must be \a epsilon -valid.  Test with
-     * Environment::is_valid(epsilon).
-     *
-     * \remarks  O(n log(n)) average case time complexity, where n is the
-     * number of vertices in the Evironment (resp. Polygon).
-     */
-    Visibility_Polygon(const Point& observer,
-		       const Environment& environment_temp,
-		       double epsilon=0.0);
-    /** \brief visibility set of a Point in a Polygon
-     *
-     * \pre \a observer is in \a polygon_temp (w/in \a epsilon ) and
-     * has been epsilon-snapped to the Polygon using the methods
-     * Point::snap_to_vertices_of() and Point::snap_to_boundary_of().
-     * \a environment_temp must be \a epsilon -valid.  Test with
-     * Environment::is_valid(epsilon).
-     *
-     * \remarks  less efficient because constructs an Environment from
-     * a Polygon and then calls the other Visibility_Polygon constructor.
-     * O(n log(n)) average case time complexity, where n is the
-     * number of vertices in the Evironment (resp. Polygon).
-     */
-    Visibility_Polygon(const Point& observer,
-		       const Polygon& polygon_temp,
-		       double epsilon=0.0);
-    //Accessors
-    //std::vector<bool> get_gap_edges(double epsilon=0.0) { return gap_edges_; }
-    /// location of observer which induced the visibility polygon
-    Point observer() const
-    { return observer_; }
-    //Mutators
-  private:
-    //ith entry of gap_edges is true iff the edge following ith vertex
-    //is a gap edge (not solid).
-    //std::vector<bool> gap_edges_;
-    Point observer_;
-
-    struct Polar_Edge
-    {
-      Polar_Point first;
-      Polar_Point second;
-      Polar_Edge() { }
-      Polar_Edge(const Polar_Point& ppoint1,
-		 const Polar_Point& ppoint2) :
-	first(ppoint1), second(ppoint2) {}
-    };
-
-    class Polar_Point_With_Edge_Info : public Polar_Point
-    {
-    public:
-      std::list<Polar_Edge>::iterator incident_edge;
-      bool is_first;  //True iff polar_point is the first_point of the
-		      //Polar_Edge pointed to by
-		      //incident_edge.
-      void set_polar_point(const Polar_Point& ppoint_temp)
-      {
-	set_polar_origin( ppoint_temp.polar_origin() );
-	set_x( ppoint_temp.x() );
-	set_y( ppoint_temp.y() );
-	set_range( ppoint_temp.range() );
-	set_bearing( ppoint_temp.bearing() );
-      }
-      //The operator < is the same as for Polar_Point with one
-      //exception.  If two vertices have equal coordinates, but one is
-      //the first point of its respecitve edge and the other is the
-      //second point of its respective edge, then the vertex which is
-      //the second point of its respective edge is considered
-      //lexicographically smaller.
-      friend bool operator < (const Polar_Point_With_Edge_Info& ppwei1,
-		       const Polar_Point_With_Edge_Info& ppwei2)
-      {
-	if( Polar_Point(ppwei1) == Polar_Point(ppwei2)
-	    and !ppwei1.is_first and ppwei2.is_first )
-	  return true;
-	else
-	  return Polar_Point(ppwei1) < Polar_Point(ppwei2);
-      }
-    };
-
-    //Strict weak ordering (acts like <) for pointers to Polar_Edges.
-    //Used to sort the priority_queue q2 used in the radial line sweep
-    //of Visibility_Polygon constructors.  Let p1 be a pointer to
-    //Polar_Edge e1 and p2 be a pointer to Polar_Edge e2.  Then p1 is
-    //considered greater (higher priority) than p2 if the distance
-    //from the observer (pointed to by observer_pointer) to e1 along
-    //the direction to current_vertex is smaller than the distance
-    //from the observer to e2 along the direction to current_vertex.
-    class Incident_Edge_Compare
-    {
-      const Point *const observer_pointer;
-      const Polar_Point_With_Edge_Info *const current_vertex_pointer;
-      double epsilon;
-    public:
-      Incident_Edge_Compare(const Point& observer,
-			    const Polar_Point_With_Edge_Info& current_vertex,
-			    double epsilon_temp) :
-	observer_pointer(&observer),
-	current_vertex_pointer(&current_vertex),
-	epsilon(epsilon_temp) { }
-      bool operator () (std::list<Polar_Edge>::iterator e1,
-			std::list<Polar_Edge>::iterator e2) const
-      {
-	Polar_Point k1, k2;
-	Line_Segment xing1 = intersection( Ray(*observer_pointer,
-					   current_vertex_pointer->bearing()),
-					   Line_Segment(e1->first,
-							e1->second),
-					   epsilon);
-	Line_Segment xing2 = intersection( Ray(*observer_pointer,
-					   current_vertex_pointer->bearing()),
-					   Line_Segment(e2->first,
-							e2->second),
-					   epsilon);
-	if( xing1.size() > 0 and xing2.size() > 0 ){
-	  k1 = Polar_Point( *observer_pointer,
-			    xing1.first() );
-	  k2 = Polar_Point( *observer_pointer,
-			    xing2.first() );
-	  if( k1.range() <= k2.range() )
-	    return false;
-	  return true;
-	}
-	//Otherwise infeasible edges are given higher priority, so they
-	//get pushed out the top of the priority_queue's (q2's)
-	//heap.
-	else if( xing1.size() == 0 and xing2.size() > 0 )
-	  return false;
-	else if( xing1.size() > 0 and xing2.size() == 0 )
-	  return true;
-	else
-	  return true;
-      }
-    };
-
-    bool is_spike( const Point& observer,
-		   const Point& point1,
-		   const Point& point2,
-		   const Point& point3,
-		   double epsilon=0.0 ) const;
-
-    //For eliminating spikes as they appear.  In the
-    //Visibility_Polygon constructors, these are checked every time a
-    //Point is added to vertices.
-    void chop_spikes_at_back(const Point& observer,
-			     double epsilon);
-    void chop_spikes_at_wrap_around(const Point& observer,
-				    double epsilon);
-    void chop_spikes(const Point& observer,
-		     double epsilon);
-    //For debugging Visibility_Polygon constructors.
-    //Prints current_vertex and active_edge data to screen.
-    void print_cv_and_ae(const Polar_Point_With_Edge_Info& current_vertex,
-			 const std::list<Polar_Edge>::iterator&
-			 active_edge);
-  };
-
-
-  /** \brief  visibility graph of points in an Environment,
-   *          represented by adjacency matrix
+  unsigned n() const;
+  /** \brief  total reflex vertex count (nonconvex vertices)
    *
-   * \remarks  used for shortest path planning in the
-   * Environment::shortest_path() method
-   *
-   * \todo Add method to prune edges for faster shortest path
-   * calculation, e.g., exclude concave vertices and only include
-   * tangent edges as described in ``Robot Motion Planning" (Ch. 4
-   * Sec. 1) by J.C. Latombe.
+   * \author  Karl J. Obermeyer
+   * \remarks  time complexity O(n), where n is the number of
+   * vertices representing the Environment
    */
-  class  Visibility_Graph
-  {
+  unsigned r() const;
+  /** \brief  true iff lexicographically smallest vertex is first in
+   *          each list of vertices representing a Polygon of the
+   *          Environment
+   *
+   * \author  Karl J. Obermeyer
+   * \remarks  lex. comparison is very sensitive to perturbations if
+   * two Points nearly define a line parallel to one of the axes
+   */
+  bool is_in_standard_form() const;
+  /** \brief  true iff \a epsilon -valid
+   *
+   * \a epsilon -valid means (i) the outer boundary and holes are
+   * pairwise \a epsilon -disjoint (no two features should come
+   * within \a epsilon of each other) simple polygons, (ii) outer
+   * boundary is oriented ccw, and (iii) holes are oriented cw.
+   *
+   * \author  Karl J. Obermeyer
+   *
+   * \pre  Environment has greater than 2 vertices
+   * (otherwise it can't even have nonzero area)
+   * \remarks time complexity O(h^2*n^2), where h is the number of
+   * holes and n is the number of vertices representing the
+   * Environment
+   */
+  bool is_valid(double epsilon = 0.0) const;
+  /** \brief  sum of perimeter lengths of outer boundary and holes
+   *
+   * \author  Karl J. Obermeyer
+   * \remarks O(n) time complexity, where n is the number of
+   * vertices representing the Environment
+   */
+  double boundary_length() const;
+  /** \brief (obstacle/hole free) area of the Environment
+   *
+   * \author  Karl J. Obermeyer
+   * \remarks  O(n) time complexity, where n is the number of
+   * vertices representing the Environment
+   */
+  double area() const;
+  /** \brief  Euclidean diameter
+   *
+   * \author  Karl J. Obermeyer
+   * \pre Environment has greater than 0 vertices
+   * \return  maximum Euclidean distance between all pairs of
+   * vertices
+   * \remarks  time complexity O(n^2), where n is the number of
+   * vertices representing the Environment
+   */
+  double diameter() const { return outer_boundary_.diameter(); }
+  /** \brief box which fits snugly around the Environment
+   *
+   * \author  Karl J. Obermeyer
+   * \pre Environment has greater than 0 vertices
+   */
+  Bounding_Box bbox() const { return outer_boundary_.bbox(); }
+  /** \brief get STL vector of \a count Points randomly situated
+   *         within \a epsilon of the Environment
+   *
+   * \author  Karl J. Obermeyer
+   * \pre  the Environment has positive area
+   */
+  std::vector<Point> random_points(const unsigned &count,
+                                   double epsilon = 0.0) const;
+  /** \brief  compute a shortest path between 2 Points
+   *
+   * Uses the classical visibility graph method as described, e.g.,
+   * in ``Robot Motion Planning" (Ch. 4 Sec. 1) by J.C. Latombe.
+   * Specifically, an A* search is performed on the visibility graph
+   * using the Euclidean distance as the heuristic function.
+   *
+   * \author  Karl J. Obermeyer
+   *
+   * \pre \a start and \a finish must be in the environment.
+   * Environment must be \a epsilon -valid.  Test with
+   * Environment::is_valid(epsilon).
+   *
+   * \remarks  If multiple shortest path queries are made for the
+   * same Envrionment, it is better to precompute the
+   * Visibility_Graph. For a precomputed Visibility_Graph, the time
+   * complexity of a shortest_path() query is O(n^2), where n is the
+   * number of vertices representing the Environment.
+   *
+   * \todo  return not just one, but all shortest paths (w/in
+   * epsilon), e.g., returning a std::vector<Polyline>)
+   */
+  Polyline shortest_path(const Point &start, const Point &finish,
+                         const Visibility_Graph &visibility_graph,
+                         double epsilon = 0.0);
+  /** \brief  compute shortest path between 2 Points
+   *
+   * \author  Karl J. Obermeyer
+   *
+   * \pre \a start and \a finish must be in the environment.
+   * Environment must be \a epsilon -valid.  Test with
+   * Environment::is_valid(epsilon).
+   *
+   * \remarks  For single shortest path query, visibility graph is
+   * not precomputed.  Time complexity O(n^3), where n is the number
+   * of vertices representing the Environment.
+   */
+  Polyline shortest_path(const Point &start, const Point &finish,
+                         double epsilon = 0.0);
+  /** \brief  compute the faces (partition cells) of an arrangement
+   *          of Line_Segments inside the Environment
+   *
+   * \author  Karl J. Obermeyer
+   * \todo  finish this
+   */
+  std::vector<Polygon>
+  compute_partition_cells(std::vector<Line_Segment> partition_inducing_segments,
+                          double epsilon = 0.0) {
+    std::vector<Polygon> cells;
+    return cells;
+  }
+  /** \brief  write lists of vertices to *.environment file
+   *
+   * uses intuitive human and computer readable decimal format with
+   * display precision \a fios_precision_temp
+   * \author  Karl J. Obermeyer
+   * \pre  \a fios_precision_temp >=1
+   */
+  void write_to_file(const std::string &filename,
+                     int fios_precision_temp = FIOS_PRECISION);
+  // Mutators
+  /** \brief  raw access to Polygons
+   *
+   * An argument of 0 accesses the outer boundary, 1 and above
+   * access the holes.
+   * \author  Karl J. Obermeyer
+   * \remarks  for efficiency, no bounds check; usually trying to
+   * access out of bounds causes a bus error
+   */
+  Polygon &operator[](unsigned i) {
+    if (i == 0) {
+      return outer_boundary_;
+    } else {
+      return holes_[i - 1];
+    }
+  }
+  // Mutators
+  /** \brief  raw access to vertices via flattened index
+   *
+   * By flattened index is intended the label given to a vertex if
+   * you were to label all the vertices from 0 to n-1 (where n is
+   * the number of vertices representing the Environment) starting
+   * with the first vertex of the outer boundary and progressing in
+   * order through all the remaining vertices of the outer boundary
+   * and holes.
+   * \author  Karl J. Obermeyer
+   * \remarks  for efficiency, no bounds check; usually trying to
+   * access out of bounds causes a bus error.
+   */
+  Point &operator()(unsigned k);
+  /// set outer boundary
+  void set_outer_boundary(const Polygon &polygon_temp) {
+    outer_boundary_ = polygon_temp;
+    update_flattened_index_key();
+  }
+  /// add hole
+  void add_hole(const Polygon &polygon_temp) {
+    holes_.push_back(polygon_temp);
+    update_flattened_index_key();
+  }
+  /** \brief enforces outer boundary vertices are listed ccw and
+   *         holes listed cw, and that these lists begin with respective
+   *         lexicographically smallest vertex
+   *
+   * \author  Karl J. Obermeyer
+   * \remarks  O(n) time complexity, where n is the number of
+   * vertices representing the Environment.  Lex. comparison is very
+   * sensitive to perturbations if two Points nearly define a line
+   * parallel to one of the axes.
+   */
+  void enforce_standard_form();
+  /** \brief eliminates vertices which are (\a epsilon) - colinear
+   *         with their respective neighbors
+   *
+   * \author  Karl J. Obermeyer
+   * \post  the Euclidean distance between each vertex and the line
+   * segment connecting its neighbors is at least \a epsilon
+   * \remarks time complexity O(n), where n is the number of
+   * vertices representing the the Environment
+   */
+  void eliminate_redundant_vertices(double epsilon = 0.0);
+  /** \brief  reverse (cyclic) order of vertices belonging to holes
+   *          only
+   *
+   * \remarks  vertex first in each hole's list is held first
+   */
+  void reverse_holes();
+
+private:
+  Polygon outer_boundary_;
+  // obstacles
+  std::vector<Polygon> holes_;
+  // allows constant time access to vertices via operator () with
+  // flattened index as argument
+  std::vector<std::pair<unsigned, unsigned>> flattened_index_key_;
+  // Must call if size of outer_boundary and/or holes_ changes.  Time
+  // complexity O(n), where n is the number of vertices representing
+  // the Environment.
+  void update_flattened_index_key();
+  // converts flattened index to index pair (hole #, vertex #) in
+  // time O(n), where n is the number of vertices representing the
+  // Environment
+  std::pair<unsigned, unsigned> one_to_two(unsigned k) const;
+  // node used for search tree of A* search in shortest_path() method
+  class Shortest_Path_Node {
   public:
-    //Constructors
-    /// default to empty
-    Visibility_Graph() { n_=0; adjacency_matrix_ = NULL; }
-    /// copy
-    Visibility_Graph( const Visibility_Graph& vg2 );
-    /** \brief  construct the visibility graph of Environment vertices
-     *
-     * \author  Karl J. Obermeyer
-     *
-     * \pre \a environment must be \a epsilon -valid.  Test with
-     * Environment::is_valid(epsilon).
-     *
-     * \remarks  Currently this constructor simply computes the
-     * Visibility_Polygon of each vertex and checks inclusion of the
-     * other vertices, taking time complexity O(n^3), where n is the
-     * number of vertices representing the Environment.  This time
-     * complexity is not optimal. As mentioned in ``Robot Motion
-     * Planning" by J.C. Latombe p.157, there are algorithms able to
-     * construct a visibility graph for a polygonal environment with
-     * holes in time O(n^2).  The nonoptimal algorithm is being used
-     * temporarily because of (1) its ease to implement using the
-     * Visibility_Polygon class, and (2) its apparent robustness.
-     * Implementing the optimal algorithm robustly is future work.
-     */
-    Visibility_Graph(const Environment& environment, double epsilon=0.0);
-    //Constructors
-    /** \brief  construct the visibility graph of Points in an Environment
-     *
-     * \pre \a environment must be \a epsilon -valid.  Test with
-     * Environment::is_valid(epsilon).
-     *
-     * \author Karl J. Obermeyer \remarks Currently this constructor
-     * simply computes the Visibility_Polygon of each Point and checks
-     * inclusion of the other Points, taking time complexity
-     * O(N n log(n) + N^2 n), where N is the number of Points and n is
-     * the number of vertices representing the Environment.  This time
-     * complexity is not optimal, but has been used for
-     * simplicity. More efficient algorithms are discussed in ``Robot
-     * Motion Planning" by J.C. Latombe p.157.
-     */
-    Visibility_Graph(const std::vector<Point> points,
-		     const Environment& environment, double epsilon=0.0);
-    //Constructors
-    /** \brief  construct the visibility graph of Guards in an Environment
-     *
-     * \pre \a start and \a finish must be in the environment.
-     * Environment must be \a epsilon -valid.  Test with
-     * Environment::is_valid(epsilon).
-     *
-     * \author  Karl J. Obermeyer
-     * \remarks  Currently this constructor simply computes the
-     * Visibility_Polygon of each guard and checks inclusion of the
-     * other guards, taking time complexity O(N n log(n) + N^2 n),
-     * where N is the number of guards and n is the number of vertices
-     * representing the Environment.  This time complexity is not
-     * optimal, but has been used for simplicity. More efficient
-     * algorithms are discussed in ``Robot Motion Planning" by
-     * J.C. Latombe p.157.
-     */
-    Visibility_Graph(const Guards& guards,
-		     const Environment& environment, double epsilon=0.0);
-    //Accessors
-    /** \brief  raw access to adjacency matrix data
-     *
-     * \author  Karl J. Obermeyer
-     * \param i1  Polygon index of first vertex
-     * \param j1  index of first vertex within its Polygon
-     * \param i2  Polygon index of second vertex
-     * \param j2  index of second vertex within its Polygon
-     * \return  true iff first vertex is visible from second vertex
-     * \remarks  for efficiency, no bounds check; usually trying to
-     * access out of bounds causes a bus error
-     */
-    bool operator () (unsigned i1,
-		      unsigned j1,
-		      unsigned i2,
-		      unsigned j2) const;
-    /** \brief  raw access to adjacency matrix data via flattened
-     *          indices
-     *
-     * By flattened index is intended the label given to a vertex if
-     * you were to label all the vertices from 0 to n-1 (where n is
-     * the number of vertices representing the Environment) starting
-     * with the first vertex of the outer boundary and progressing in
-     * order through all the remaining vertices of the outer boundary
-     * and holes.
-     * \author  Karl J. Obermeyer
-     * \param k1  flattened index of first vertex
-     * \param k1  flattened index of second vertex
-     * \return  true iff first vertex is visible from second vertex
-     * \remarks  for efficiency, no bounds check; usually trying to
-     * access out of bounds causes a bus error
-     */
-    bool operator () (unsigned k1,
-		      unsigned k2) const;
-    /// \brief  total number of vertices in corresponding Environment
-    unsigned n() const { return n_; }
-    //Mutators
-    /** \brief  raw access to adjacency matrix data
-     *
-     * \author  Karl J. Obermeyer
-     * \param i1  Polygon index of first vertex
-     * \param j1  index of first vertex within its Polygon
-     * \param i2  Polygon index of second vertex
-     * \param j2  index of second vertex within its Polygon
-     * \return  true iff first vertex is visible from second vertex
-     * \remarks  for efficiency, no bounds check; usually trying to
-     * access out of bounds causes a bus error
-     */
-    bool& operator () (unsigned i1,
-		       unsigned j1,
-		       unsigned i2,
-		       unsigned j2);
-    /** \brief  raw access to adjacency matrix data via flattened
-     *          indices
-     *
-     * By flattened index is intended the label given to a vertex if
-     * you were to label all the vertices from 0 to n-1 (where n is
-     * the number of vertices representing the Environment) starting
-     * with the first vertex of the outer boundary and progressing in
-     * order through all the remaining vertices of the outer boundary
-     * and holes.
-     * \author  Karl J. Obermeyer
-     * \param k1  flattened index of first vertex
-     * \param k1  flattened index of second vertex
-     * \return  true iff first vertex is visible from second vertex
-     * \remarks  for efficiency, no bounds check; usually trying to
-     * access out of bounds causes a bus error
-     */
-    bool& operator () (unsigned k1,
-		       unsigned k2);
-    /// assignment operator
-    Visibility_Graph& operator =
-    (const Visibility_Graph& visibility_graph_temp);
-    /// destructor
-    virtual ~Visibility_Graph();
-  private:
-    //total number of vertices of corresponding Environment
-    unsigned n_;
-    //the number of vertices in each Polygon of corresponding Environment
-    std::vector<unsigned> vertex_counts_;
-    // n_-by-n_ adjacency matrix data stored as 2D dynamic array
-    bool **adjacency_matrix_;
-    //converts vertex pairs (hole #, vertex #) to flattened index
-    unsigned two_to_one(unsigned i,
-			unsigned j) const;
+    // flattened index of corresponding Environment vertex
+    // convention vertex_index = n() => corresponds to start Point
+    // vertex_index = n() + 1 => corresponds to finish Point
+    unsigned vertex_index;
+    // pointer to self in search tree.
+    std::list<Shortest_Path_Node>::iterator search_tree_location;
+    // pointer to parent in search tree.
+    std::list<Shortest_Path_Node>::iterator parent_search_tree_location;
+    // Geodesic distance from start Point.
+    double cost_to_come;
+    // Euclidean distance to finish Point.
+    double estimated_cost_to_go;
+    // std::vector<Shortest_Path_Node> expand();
+    bool operator<(const Shortest_Path_Node &spn2) const {
+      double f1 = this->cost_to_come + this->estimated_cost_to_go;
+      double f2 = spn2.cost_to_come + spn2.estimated_cost_to_go;
+      if (f1 < f2)
+        return true;
+      else if (f2 < f1)
+        return false;
+      else if (this->vertex_index < spn2.vertex_index)
+        return true;
+      else if (this->vertex_index > spn2.vertex_index)
+        return false;
+      else if (&(*(this->parent_search_tree_location)) <
+               &(*(spn2.parent_search_tree_location)))
+        return true;
+      else
+        return false;
+    }
+    // print member data for debugging
+    void print() const {
+      std::cout << "         vertex_index = " << vertex_index << std::endl
+                << "parent's vertex_index = "
+                << parent_search_tree_location->vertex_index << std::endl
+                << "         cost_to_come = " << cost_to_come << std::endl
+                << " estimated_cost_to_go = " << estimated_cost_to_go
+                << std::endl;
+    }
+  };
+};
+
+/// printing Environment
+std::ostream &operator<<(std::ostream &outs,
+                         const Environment &environment_temp);
+
+/** \brief  set of Guards represented by a list of Points
+ */
+class Guards {
+public:
+  friend class Visibility_Graph;
+  // Constructors
+  /// default to empty
+  Guards() {}
+  /** \brief  construct from *.guards file
+   *
+   * \author  Karl J. Obermeyer
+   */
+  Guards(const std::string &filename);
+  /// construct from STL vector of Points
+  Guards(const std::vector<Point> &positions) { positions_ = positions; }
+  // Accessors
+  /** \brief  raw access to guard position Points
+   *
+   * \author  Karl J. Obermeyer
+   * \remarks  for efficiency, no bounds check; usually trying to
+   * access out of bounds causes a bus error
+   */
+  const Point &operator[](unsigned i) const { return positions_[i]; }
+  /// guard count
+  unsigned N() const { return positions_.size(); }
+  /// true iff positions are lexicographically ordered
+  bool are_lex_ordered() const;
+  /// true iff no two guards are w/in epsilon of each other
+  bool noncolocated(double epsilon = 0.0) const;
+  /// true iff all guards are located in \a polygon_temp
+  bool in(const Polygon &polygon_temp, double epsilon = 0.0) const;
+  /// true iff all guards are located in \a environment_temp
+  bool in(const Environment &environment_temp, double epsilon = 0.0) const;
+  /** \brief  Euclidean diameter
+   *
+   * \author  Karl J. Obermeyer
+   * \pre  greater than 0 guards
+   * \return  maximum Euclidean distance between all pairs of
+   * vertices
+   * \remarks  time complexity O(N^2), where N is the number of
+   * guards
+   */
+  double diameter() const;
+  /** \brief box which fits snugly around the Guards
+   *
+   * \author  Karl J. Obermeyer
+   * \pre  greater than 0 guards
+   */
+  Bounding_Box bbox() const;
+  /** \brief  write list of positions to *.guards file
+   *
+   * Uses intuitive human and computer readable decimal format with
+   * display precision \a fios_precision_temp.
+   * \author  Karl J. Obermeyer
+   * \pre  \a fios_precision_temp >=1
+   */
+  void write_to_file(const std::string &filename,
+                     int fios_precision_temp = FIOS_PRECISION);
+  // Mutators
+  /** \brief  raw access to guard position Points
+   *
+   * \author  Karl J. Obermeyer
+   * \remarks  for efficiency, no bounds check; usually trying to
+   * access out of bounds causes a bus error
+   */
+  Point &operator[](unsigned i) { return positions_[i]; }
+  /// add a guard
+  void push_back(const Point &point_temp) { positions_.push_back(point_temp); }
+  /// set positions with STL vector of Points
+  void set_positions(const std::vector<Point> &positions_temp) {
+    positions_ = positions_temp;
+  }
+  /** \brief sort positions in lexicographic order
+   *
+   * from (lowest x, then lowest y) to (highest x, then highest y)
+   * \author  Karl J. Obermeyer
+   * \remarks time complexity O(N logN), where N is the guard count.
+   * Lex. comparison is very sensitive to perturbations if two
+   * Points nearly define a line parallel to one of the axes.
+   */
+  void enforce_lex_order();
+  /// reverse order of positions
+  void reverse();
+  /** \brief relocate each guard to closest vertex if within
+   *         \a epsilon of some vertex (of \a environment_temp)
+   *
+   * \author  Karl J. Obermeyer
+   * \pre  the guards' position data are numbers and \a environment_temp
+   * is nonempty
+   * \post if a guard was a Euclidean distance no greater
+   * than \a epsilon from any vertex of \a environment_temp, then it
+   * will be repositioned to coincide with the closest such vertex
+   * \remarks O(N*n) time complexity, where N is the guard count
+   * and n is the number of vertices in \a environment_temp.
+   */
+  void snap_to_vertices_of(const Environment &environment_temp,
+                           double epsilon = 0.0);
+
+  /** \brief relocate each guard to closest vertex if within
+   *         \a epsilon of some vertex (of \a environment_temp)
+   *
+   * \author  Karl J. Obermeyer
+   * \pre  the guards' position data are numbers and \a polygon_temp
+   * is nonempty
+   * \post if a guard was a Euclidean distance no greater
+   * than \a epsilon from any vertex of \a polygon_temp, then it
+   * will be repositioned to coincide with the closest such vertex
+   * \remarks O(N*n) time complexity, where N is the guard count
+   * and n is the number of vertices in \a polygon_temp
+   */
+  void snap_to_vertices_of(const Polygon &polygon_temp, double epsilon = 0.0);
+  /** \brief  relocate each guard to closest Point on boundary if
+   *	        within \a epsilon of the boundary (of \a environment_temp)
+   *
+   * \author  Karl J. Obermeyer
+   * \pre  the guards' position data are numbers and \a environment_temp
+   * is nonempty
+   * \post If the calling Point was a Euclidean distance no greater
+   * than \a epsilon from the boundary of \a environment_temp, then it
+   * will be repositioned to it's projection onto that boundary
+   * \remarks O(N*n) time complexity, where N is the guard count and
+   * n is the number of vertices in \a environment_temp
+   */
+  void snap_to_boundary_of(const Environment &environment_temp,
+                           double epsilon = 0.0);
+  /** \brief  relocate each guard to closest Point on boundary if
+   *	        within \a epsilon of the boundary (of \a polygon_temp)
+   *
+   * \author  Karl J. Obermeyer
+   * \pre  the guards' position data are numbers and \a polygon_temp
+   * is nonempty
+   * \post If the calling Point was a Euclidean distance no greater
+   * than \a epsilon from the boundary of \a polygon_temp, then it
+   * will be repositioned to it's projection onto that boundary
+   * \remarks O(N*n) time complexity, where N is the guard count and
+   * n is the number of vertices in \a polygon_temp
+   */
+  void snap_to_boundary_of(const Polygon &polygon_temp, double epsilon = 0.0);
+
+private:
+  std::vector<Point> positions_;
+};
+
+/// print Guards
+std::ostream &operator<<(std::ostream &outs, const Guards &guards);
+
+/** \brief visibility polygon of a Point in an Environment or Polygon
+ *
+ * A Visibility_Polygon represents the closure of the set of all
+ * points in an environment which are {\it clearly visible} from a
+ * point (the observer).  Two Points p1 and p2 are (mutually) {\it
+ * clearly visible} in an environment iff the relative interior of
+ * the line segment connecting p1 and p2 does not intersect the
+ * boundary of the environment.
+ *
+ * \remarks  average case time complexity O(n log(n)), where n is the
+ * number of vertices in the Evironment (resp. Polygon).  Note the
+ * Standard Library's sort() function performs O(n log(n))
+ * comparisons (both average and worst-case) and the sort() member
+ * function of an STL list performs "approximately O(n log(n))
+ * comparisons".  For robustness, any Point (observer) should be \a
+ * epsilon -snapped to the environment boundary and vertices before
+ * computing its Visibility_Polygon (use the Point methods
+ * snap_to_vertices_of(...) and snap_to_boundary_of(...) ).
+ */
+class Visibility_Polygon : public Polygon {
+public:
+  // Constructors
+  /// default to empty
+  Visibility_Polygon() {}
+  //:TRICKY:
+  /** \brief visibility set of a Point in an Environment
+   *
+   * \author  Karl J. Obermeyer
+   *
+   * \pre \a observer is in \a environment_temp (w/in \a epsilon )
+   * and has been epsilon-snapped to the Environment using the
+   * method Point::snap_to_boundary_of() followed by (order is
+   * important) Point::snap_to_vertices_of(). \a environment_temp
+   * must be \a epsilon -valid.  Test with
+   * Environment::is_valid(epsilon).
+   *
+   * \remarks  O(n log(n)) average case time complexity, where n is the
+   * number of vertices in the Evironment (resp. Polygon).
+   */
+  Visibility_Polygon(const Point &observer, const Environment &environment_temp,
+                     double epsilon = 0.0);
+  /** \brief visibility set of a Point in a Polygon
+   *
+   * \pre \a observer is in \a polygon_temp (w/in \a epsilon ) and
+   * has been epsilon-snapped to the Polygon using the methods
+   * Point::snap_to_vertices_of() and Point::snap_to_boundary_of().
+   * \a environment_temp must be \a epsilon -valid.  Test with
+   * Environment::is_valid(epsilon).
+   *
+   * \remarks  less efficient because constructs an Environment from
+   * a Polygon and then calls the other Visibility_Polygon constructor.
+   * O(n log(n)) average case time complexity, where n is the
+   * number of vertices in the Evironment (resp. Polygon).
+   */
+  Visibility_Polygon(const Point &observer, const Polygon &polygon_temp,
+                     double epsilon = 0.0);
+  // Accessors
+  // std::vector<bool> get_gap_edges(double epsilon=0.0) { return gap_edges_; }
+  /// location of observer which induced the visibility polygon
+  Point observer() const { return observer_; }
+  // Mutators
+private:
+  // ith entry of gap_edges is true iff the edge following ith vertex
+  // is a gap edge (not solid).
+  // std::vector<bool> gap_edges_;
+  Point observer_;
+
+  struct Polar_Edge {
+    Polar_Point first;
+    Polar_Point second;
+    Polar_Edge() {}
+    Polar_Edge(const Polar_Point &ppoint1, const Polar_Point &ppoint2)
+        : first(ppoint1), second(ppoint2) {}
   };
 
+  class Polar_Point_With_Edge_Info : public Polar_Point {
+  public:
+    std::list<Polar_Edge>::iterator incident_edge;
+    bool is_first; // True iff polar_point is the first_point of the
+                   // Polar_Edge pointed to by
+                   // incident_edge.
+    void set_polar_point(const Polar_Point &ppoint_temp) {
+      set_polar_origin(ppoint_temp.polar_origin());
+      set_x(ppoint_temp.x());
+      set_y(ppoint_temp.y());
+      set_range(ppoint_temp.range());
+      set_bearing(ppoint_temp.bearing());
+    }
+    // The operator < is the same as for Polar_Point with one
+    // exception.  If two vertices have equal coordinates, but one is
+    // the first point of its respecitve edge and the other is the
+    // second point of its respective edge, then the vertex which is
+    // the second point of its respective edge is considered
+    // lexicographically smaller.
+    friend bool operator<(const Polar_Point_With_Edge_Info &ppwei1,
+                          const Polar_Point_With_Edge_Info &ppwei2) {
+      if (Polar_Point(ppwei1) == Polar_Point(ppwei2) and !ppwei1.is_first and
+          ppwei2.is_first)
+        return true;
+      else
+        return Polar_Point(ppwei1) < Polar_Point(ppwei2);
+    }
+  };
 
-  /// print Visibility_Graph adjacency matrix
-  std::ostream& operator << (std::ostream& outs,
-			     const Visibility_Graph& visibility_graph);
+  // Strict weak ordering (acts like <) for pointers to Polar_Edges.
+  // Used to sort the priority_queue q2 used in the radial line sweep
+  // of Visibility_Polygon constructors.  Let p1 be a pointer to
+  // Polar_Edge e1 and p2 be a pointer to Polar_Edge e2.  Then p1 is
+  // considered greater (higher priority) than p2 if the distance
+  // from the observer (pointed to by observer_pointer) to e1 along
+  // the direction to current_vertex is smaller than the distance
+  // from the observer to e2 along the direction to current_vertex.
+  class Incident_Edge_Compare {
+    const Point *const observer_pointer;
+    const Polar_Point_With_Edge_Info *const current_vertex_pointer;
+    double epsilon;
 
-}
+  public:
+    Incident_Edge_Compare(const Point &observer,
+                          const Polar_Point_With_Edge_Info &current_vertex,
+                          double epsilon_temp)
+        : observer_pointer(&observer), current_vertex_pointer(&current_vertex),
+          epsilon(epsilon_temp) {}
+    bool operator()(std::list<Polar_Edge>::iterator e1,
+                    std::list<Polar_Edge>::iterator e2) const {
+      Polar_Point k1, k2;
+      Line_Segment xing1 = intersection(
+          Ray(*observer_pointer, current_vertex_pointer->bearing()),
+          Line_Segment(e1->first, e1->second), epsilon);
+      Line_Segment xing2 = intersection(
+          Ray(*observer_pointer, current_vertex_pointer->bearing()),
+          Line_Segment(e2->first, e2->second), epsilon);
+      if (xing1.size() > 0 and xing2.size() > 0) {
+        k1 = Polar_Point(*observer_pointer, xing1.first());
+        k2 = Polar_Point(*observer_pointer, xing2.first());
+        if (k1.range() <= k2.range())
+          return false;
+        return true;
+      }
+      // Otherwise infeasible edges are given higher priority, so they
+      // get pushed out the top of the priority_queue's (q2's)
+      // heap.
+      else if (xing1.size() == 0 and xing2.size() > 0)
+        return false;
+      else if (xing1.size() > 0 and xing2.size() == 0)
+        return true;
+      else
+        return true;
+    }
+  };
 
-#endif //VISILIBITY_H
+  bool is_spike(const Point &observer, const Point &point1, const Point &point2,
+                const Point &point3, double epsilon = 0.0) const;
+
+  // For eliminating spikes as they appear.  In the
+  // Visibility_Polygon constructors, these are checked every time a
+  // Point is added to vertices.
+  void chop_spikes_at_back(const Point &observer, double epsilon);
+  void chop_spikes_at_wrap_around(const Point &observer, double epsilon);
+  void chop_spikes(const Point &observer, double epsilon);
+  // For debugging Visibility_Polygon constructors.
+  // Prints current_vertex and active_edge data to screen.
+  void print_cv_and_ae(const Polar_Point_With_Edge_Info &current_vertex,
+                       const std::list<Polar_Edge>::iterator &active_edge);
+};
+
+/** \brief  visibility graph of points in an Environment,
+ *          represented by adjacency matrix
+ *
+ * \remarks  used for shortest path planning in the
+ * Environment::shortest_path() method
+ *
+ * \todo Add method to prune edges for faster shortest path
+ * calculation, e.g., exclude concave vertices and only include
+ * tangent edges as described in ``Robot Motion Planning" (Ch. 4
+ * Sec. 1) by J.C. Latombe.
+ */
+class Visibility_Graph {
+public:
+  // Constructors
+  /// default to empty
+  Visibility_Graph() {
+    n_ = 0;
+    adjacency_matrix_ = NULL;
+  }
+  /// copy
+  Visibility_Graph(const Visibility_Graph &vg2);
+  /** \brief  construct the visibility graph of Environment vertices
+   *
+   * \author  Karl J. Obermeyer
+   *
+   * \pre \a environment must be \a epsilon -valid.  Test with
+   * Environment::is_valid(epsilon).
+   *
+   * \remarks  Currently this constructor simply computes the
+   * Visibility_Polygon of each vertex and checks inclusion of the
+   * other vertices, taking time complexity O(n^3), where n is the
+   * number of vertices representing the Environment.  This time
+   * complexity is not optimal. As mentioned in ``Robot Motion
+   * Planning" by J.C. Latombe p.157, there are algorithms able to
+   * construct a visibility graph for a polygonal environment with
+   * holes in time O(n^2).  The nonoptimal algorithm is being used
+   * temporarily because of (1) its ease to implement using the
+   * Visibility_Polygon class, and (2) its apparent robustness.
+   * Implementing the optimal algorithm robustly is future work.
+   */
+  Visibility_Graph(const Environment &environment, double epsilon = 0.0);
+  // Constructors
+  /** \brief  construct the visibility graph of Points in an Environment
+   *
+   * \pre \a environment must be \a epsilon -valid.  Test with
+   * Environment::is_valid(epsilon).
+   *
+   * \author Karl J. Obermeyer \remarks Currently this constructor
+   * simply computes the Visibility_Polygon of each Point and checks
+   * inclusion of the other Points, taking time complexity
+   * O(N n log(n) + N^2 n), where N is the number of Points and n is
+   * the number of vertices representing the Environment.  This time
+   * complexity is not optimal, but has been used for
+   * simplicity. More efficient algorithms are discussed in ``Robot
+   * Motion Planning" by J.C. Latombe p.157.
+   */
+  Visibility_Graph(const std::vector<Point> points,
+                   const Environment &environment, double epsilon = 0.0);
+  // Constructors
+  /** \brief  construct the visibility graph of Guards in an Environment
+   *
+   * \pre \a start and \a finish must be in the environment.
+   * Environment must be \a epsilon -valid.  Test with
+   * Environment::is_valid(epsilon).
+   *
+   * \author  Karl J. Obermeyer
+   * \remarks  Currently this constructor simply computes the
+   * Visibility_Polygon of each guard and checks inclusion of the
+   * other guards, taking time complexity O(N n log(n) + N^2 n),
+   * where N is the number of guards and n is the number of vertices
+   * representing the Environment.  This time complexity is not
+   * optimal, but has been used for simplicity. More efficient
+   * algorithms are discussed in ``Robot Motion Planning" by
+   * J.C. Latombe p.157.
+   */
+  Visibility_Graph(const Guards &guards, const Environment &environment,
+                   double epsilon = 0.0);
+  // Accessors
+  /** \brief  raw access to adjacency matrix data
+   *
+   * \author  Karl J. Obermeyer
+   * \param i1  Polygon index of first vertex
+   * \param j1  index of first vertex within its Polygon
+   * \param i2  Polygon index of second vertex
+   * \param j2  index of second vertex within its Polygon
+   * \return  true iff first vertex is visible from second vertex
+   * \remarks  for efficiency, no bounds check; usually trying to
+   * access out of bounds causes a bus error
+   */
+  bool operator()(unsigned i1, unsigned j1, unsigned i2, unsigned j2) const;
+  /** \brief  raw access to adjacency matrix data via flattened
+   *          indices
+   *
+   * By flattened index is intended the label given to a vertex if
+   * you were to label all the vertices from 0 to n-1 (where n is
+   * the number of vertices representing the Environment) starting
+   * with the first vertex of the outer boundary and progressing in
+   * order through all the remaining vertices of the outer boundary
+   * and holes.
+   * \author  Karl J. Obermeyer
+   * \param k1  flattened index of first vertex
+   * \param k1  flattened index of second vertex
+   * \return  true iff first vertex is visible from second vertex
+   * \remarks  for efficiency, no bounds check; usually trying to
+   * access out of bounds causes a bus error
+   */
+  bool operator()(unsigned k1, unsigned k2) const;
+  /// \brief  total number of vertices in corresponding Environment
+  unsigned n() const { return n_; }
+  // Mutators
+  /** \brief  raw access to adjacency matrix data
+   *
+   * \author  Karl J. Obermeyer
+   * \param i1  Polygon index of first vertex
+   * \param j1  index of first vertex within its Polygon
+   * \param i2  Polygon index of second vertex
+   * \param j2  index of second vertex within its Polygon
+   * \return  true iff first vertex is visible from second vertex
+   * \remarks  for efficiency, no bounds check; usually trying to
+   * access out of bounds causes a bus error
+   */
+  bool &operator()(unsigned i1, unsigned j1, unsigned i2, unsigned j2);
+  /** \brief  raw access to adjacency matrix data via flattened
+   *          indices
+   *
+   * By flattened index is intended the label given to a vertex if
+   * you were to label all the vertices from 0 to n-1 (where n is
+   * the number of vertices representing the Environment) starting
+   * with the first vertex of the outer boundary and progressing in
+   * order through all the remaining vertices of the outer boundary
+   * and holes.
+   * \author  Karl J. Obermeyer
+   * \param k1  flattened index of first vertex
+   * \param k1  flattened index of second vertex
+   * \return  true iff first vertex is visible from second vertex
+   * \remarks  for efficiency, no bounds check; usually trying to
+   * access out of bounds causes a bus error
+   */
+  bool &operator()(unsigned k1, unsigned k2);
+  /// assignment operator
+  Visibility_Graph &operator=(const Visibility_Graph &visibility_graph_temp);
+  /// destructor
+  virtual ~Visibility_Graph();
+
+private:
+  // total number of vertices of corresponding Environment
+  unsigned n_;
+  // the number of vertices in each Polygon of corresponding Environment
+  std::vector<unsigned> vertex_counts_;
+  // n_-by-n_ adjacency matrix data stored as 2D dynamic array
+  bool **adjacency_matrix_;
+  // converts vertex pairs (hole #, vertex #) to flattened index
+  unsigned two_to_one(unsigned i, unsigned j) const;
+};
+
+/// print Visibility_Graph adjacency matrix
+std::ostream &operator<<(std::ostream &outs,
+                         const Visibility_Graph &visibility_graph);
+
+} // namespace VisiLibity
+
+#endif // VISILIBITY_H


### PR DESCRIPTION
To close Issue #4, this is a PR for a change that reformatted all cpp/hpp files according to the default rules of clang-format. Going forward, if there are reasons to make adjustments to the default behavior so that the style better fits @karlobermeyer's eye, then we can definitely make those customizations. 

Closes #4. 