### PR TITLE
Issue#2: Redundant Q insertion in shortest path calculation

### DIFF
--- a/src/visilibity.cpp
+++ b/src/visilibity.cpp
@@ -2011,10 +2011,6 @@ Polyline Environment::shortest_path(const Point &start, const Point &finish,
         Q.insert(*children_itr);
       }
 
-      // If not already visited, insert into Q
-      if (!child_already_visited)
-        Q.insert(*children_itr);
-
       if (PRINTING_DEBUG_DATA) {
         std::cout << "child already visited? " << child_already_visited
                   << std::endl;


### PR DESCRIPTION
Per private correspondence, there is a redundant insertion
into the priority queue used in shortest path calculations.
This extra insertion does not effect correctness, but does
make readability harder. Removing it will help that.

Closes #3 . 